### PR TITLE
Feat #3 (ecomm/variations): add CRUD for variations and variation options with MongoDB support

### DIFF
--- a/cmd/api/server/v1/v1.go
+++ b/cmd/api/server/v1/v1.go
@@ -13,6 +13,10 @@ import (
 	categoryHandler "github.com/amorindev/go-tmpl/pkg/app/ecomm/category/api/handler"
 	categoryRepository "github.com/amorindev/go-tmpl/pkg/app/ecomm/category/repository/mongo"
 	categoryService "github.com/amorindev/go-tmpl/pkg/app/ecomm/category/service"
+	variationHandler "github.com/amorindev/go-tmpl/pkg/app/ecomm/variations/api/handler"
+	varOptionRepository "github.com/amorindev/go-tmpl/pkg/app/ecomm/variations/repository/var-option/mongo"
+	variationRepository "github.com/amorindev/go-tmpl/pkg/app/ecomm/variations/repository/variation/mongo"
+	variationService "github.com/amorindev/go-tmpl/pkg/app/ecomm/variations/service"
 	userRepository "github.com/amorindev/go-tmpl/pkg/app/users/repository/mongo"
 )
 
@@ -33,10 +37,14 @@ func New() http.Handler {
 	// Collections
 	userColl := mongoDB.Collection("users")
 	categoryColl := mongoDB.Collection("categories")
+	variationColl := mongoDB.Collection("variations")
+	varOptionColl := mongoDB.Collection("var_options")
 
 	// Repositories
 	userRepo := userRepository.NewUserRepo(mongoConn.DB, userColl)
 	categoryRepo := categoryRepository.NewCategoryRepo(mongoConn.DB, categoryColl)
+	variationRepo := variationRepository.NewVariationRepo(mongoConn.DB, variationColl)
+	varOptionRepo := varOptionRepository.NewVarOptionRepo(mongoConn.DB, varOptionColl)
 
 	// Indexes
 	err := userRepo.CreateIndexes()
@@ -47,11 +55,13 @@ func New() http.Handler {
 	// Services
 	authMethodSrv := authMethodService.NewAuthMethodSrv(userRepo)
 	categorySrv := categoryService.NewCategorySrv(categoryRepo)
+	variationSrv := variationService.NewVariationSrv(variationRepo, varOptionRepo)
 
 	// Handler
 	// Note: all subsequent handlers should also be registered using v1
 	authMethodHandler.NewAuthMethodHandler(v1, authMethodSrv)
 	categoryHandler.NewCategoryHandler(v1, categorySrv)
+	variationHandler.NewVariationHandler(v1, variationSrv)
 
 	mux.HandleFunc("GET /ping", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/pkg/app/admin/api/handler/handler.go
+++ b/pkg/app/admin/api/handler/handler.go
@@ -15,6 +15,7 @@ func NewAdminHandler(mux *http.ServeMux, apiBaseUrl string) *Handler {
 	//mux.HandleFunc("/admin/home", h.HomePage)
 	//mux.HandleFunc("/admin/other", h.OtherPage)
 	mux.HandleFunc("/admin/categories", h.CategoriesPage)
+	mux.HandleFunc("/admin/variations", h.VariationsPage)
 
 	return h
 }

--- a/pkg/app/admin/api/handler/variations.page.go
+++ b/pkg/app/admin/api/handler/variations.page.go
@@ -1,0 +1,32 @@
+package handler
+
+import (
+	"net/http"
+	"text/template"
+)
+
+func (h *Handler) VariationsPage(w http.ResponseWriter, r *http.Request) {
+	files := []string{
+		"pkg/app/admin/api/web/templates/base.html",
+		"pkg/app/admin/api/web/templates/variations.html",
+	}
+
+    ts, err := template.ParseFiles(files...)
+	if err != nil {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	data := struct {
+		ApiBaseUrl string
+        ActivePage string
+	}{
+		ApiBaseUrl: h.ApiBaseUrl,
+        ActivePage: "variation",
+	}
+
+	err = ts.ExecuteTemplate(w, "base", data)
+	if err != nil {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+	}
+}

--- a/pkg/app/admin/api/web/templates/base.html
+++ b/pkg/app/admin/api/web/templates/base.html
@@ -98,6 +98,7 @@
           <!-- <a href="/v1/admin/home" class="{{if eq .ActivePage "home"}}active{{end}}">Home</a> -->
           <!-- <a href="/v1/admin/other" class="{{if eq .ActivePage "other"}}active{{end}}">Other</a> -->
           <a href="/v1/admin/categories" class="{{if eq .ActivePage "category"}}active{{end}}">Category</a>
+          <a href="/v1/admin/variations" class="{{if eq .ActivePage "variation"}}active{{end}}">Variations</a>
         </nav>
       </div>
       <div class="main">

--- a/pkg/app/admin/api/web/templates/variations.html
+++ b/pkg/app/admin/api/web/templates/variations.html
@@ -1,0 +1,315 @@
+{{ define "title"}} Variations {{end}} {{ define "content"}}
+
+<style>
+  #msg {
+    margin-bottom: 1rem;
+  }
+
+  .table-container {
+    margin-top: 2rem;
+  } 
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 0.5rem;
+  }
+
+  th,
+  td {
+    padding: 8px;
+    border: 1px solid #1f2937;
+    text-align: left;
+  }
+
+  th {
+    background: #f4f4f4;
+  }
+
+  tr:nth-child(even) {
+    background: #f9f9f9;
+  }
+
+  tr:hover {
+    background: #f1f1f1;
+  }
+
+  button {
+    margin: 2px;
+    padding: 4px 8px;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+  }
+
+  button:hover {
+    opacity: 0.9;
+  }
+
+  button[onclick^="showModal('variation')"] {
+    background-color: #2563eb;
+    color: white;
+  }
+
+  button[onclick^="deleteVariation"] {
+    background-color: #dc2626;
+    color: white;
+  }
+
+  button[onclick^="deleteOption"] {
+    background-color: #dc2626;
+    color: white;
+  }
+
+  button[onclick^="showModal('option')"] {
+    background-color: #2563eb;
+    color: white;
+  }
+
+  button[onclick^="showModal('variation','"] {
+    background-color: #f59e0b;
+    color: white;
+  }
+
+  button[onclick^="showModal('option','"] {
+    background-color: #f59e0b;
+    color: white;
+  }
+
+  #modal {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.4);
+    justify-content: center;
+    align-items: center;
+  }
+
+  #modal form {
+    background: #fff;
+    padding: 1rem;
+    border-radius: 8px;
+    width: 300px;
+  }
+</style>
+
+<div id="msg"></div>
+
+<button onclick="showModal('variation')">➕ Add Variation</button>
+<div id="variations-container"></div>
+
+<div id="modal">
+  <form id="modal-form">
+    <h3 id="modal-title"></h3>
+    <input type="hidden" id="variation-id" />
+    <input type="hidden" id="option-id" />
+    <div>
+      <label>Name/Label:</label>
+      <input type="text" id="name" required />
+    </div>
+    <div id="value-container">
+      <label>Value:</label>
+      <input type="text" id="value" />
+    </div>
+    <button type="submit">Save</button>
+    <button type="button" onclick="closeModal()">Cancel</button>
+  </form>
+</div>
+
+<script>
+  const API = `${API_BASE}/v1/variations`;
+  const modal = document.getElementById("modal");
+  const form = document.getElementById("modal-form");
+  const container = document.getElementById("variations-container");
+
+  async function fetchVariations() {
+    const msg = document.getElementById("msg");
+    msg.textContent = "Loading...";
+    msg.style.color = "black";
+
+    try {
+      const res = await fetch(`${API}/options`);
+      if (!res.ok) throw new Error("error getting variations");
+      const variations = await res.json();
+      renderVariations(variations);
+      msg.textContent = "";
+    } catch (err) {
+      msg.textContent = err.message;
+      msg.style.color = "red";
+    }
+  }
+
+  async function fetchVariations() {
+    const msg = document.getElementById("msg");
+    msg.textContent = "Loading...";
+    msg.style.color = "black";
+
+    try {
+      const res = await fetch(`${API}/options`);
+      if (!res.ok) throw new Error("error getting variations");
+      const variations = await res.json();
+      renderVariations(variations);
+      msg.textContent = "";
+    } catch (err) {
+      msg.textContent = err.message;
+      msg.style.color = "red";
+    }
+  }
+
+  function renderVariations(variations) {
+    container.innerHTML = "";
+
+    if (!Array.isArray(variations) || variations.length === 0) {
+      const table = document.createElement("table");
+      table.innerHTML = `
+      <thead><tr><th>Name</th><th>Options</th><th>Actions</th></tr></thead>
+      <tbody>
+        <tr><td colspan="3" style="text-align:center;">No variations found</td></tr>
+      </tbody>`;
+      const wrapper = document.createElement("div");
+      wrapper.className = "table-container";
+      wrapper.appendChild(table);
+      container.appendChild(wrapper);
+      return;
+    }
+
+    variations.forEach((v) => {
+      const table = document.createElement("table");
+      table.innerHTML = `
+      <thead>
+        <tr>
+          <th colspan="3" style="text-align:left;">
+            ${v.name}
+            <span style="float:right;">
+              <button onclick="showModal('variation','${v.id}')">✏️ Update</button>
+              <button onclick="deleteVariation('${v.id}')">🗑️ Delete</button>
+              <button onclick="showModal('option','${v.id}')">➕ Add Option</button>
+            </span>
+          </th>
+        </tr>
+        <tr>
+          <th style="width:40%;">Label</th>
+          <th style="width:40%;">Value</th>
+          <th style="width:20%; text-align:right;">Actions</th>
+        </tr>
+      </thead>`;
+
+      const tbody = document.createElement("tbody");
+
+      if (!v.options || v.options.length === 0) {
+        const tr = document.createElement("tr");
+        tr.innerHTML = `<td colspan="3" style="text-align:center;">No options found</td>`;
+        tbody.appendChild(tr);
+      } else {
+        v.options.forEach((o) => {
+          const tr = document.createElement("tr");
+          tr.dataset.id = o.id;
+          tr.innerHTML = `
+          <td style="width:40%;">${o.label}</td>
+          <td style="width:40%;">${o.value || "—"}</td>
+          <td style="width:20%; text-align:right;">
+            <button onclick="showModal('option','${v.id}','${
+            o.id
+          }')">✏️ Update</button>
+            <button onclick="deleteOption('${v.id}','${
+            o.id
+          }')">🗑️ Delete</button>
+          </td>`;
+          tbody.appendChild(tr);
+        });
+      }
+
+      table.appendChild(tbody);
+      const wrapper = document.createElement("div");
+      wrapper.className = "table-container";
+      wrapper.appendChild(table);
+      container.appendChild(wrapper);
+    });
+  }
+
+  function showModal(type, variationId = null, optionId = null) {
+    modal.style.display = "flex";
+    document.getElementById("variation-id").value = variationId || "";
+    document.getElementById("option-id").value = optionId || "";
+    document.getElementById("modal-title").innerText = optionId
+      ? "Update Option"
+      : variationId && type === "option"
+      ? "Add Option"
+      : variationId
+      ? "Update Variation"
+      : "Add Variation";
+    document.getElementById("value-container").style.display =
+      type === "option" ? "block" : "none";
+  }
+
+  function closeModal() {
+    modal.style.display = "none";
+    form.reset();
+  }
+
+  form.addEventListener("submit", async (e) => {
+    e.preventDefault();
+    const variationId = document.getElementById("variation-id").value;
+    const optionId = document.getElementById("option-id").value;
+    const name = document.getElementById("name").value;
+    const value = document.getElementById("value").value || null;
+
+    try {
+      let res;
+      if (optionId) {
+        res = await fetch(`${API}/${variationId}/options/${optionId}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ label: name, value }),
+        });
+      } else if (
+        variationId &&
+        document.getElementById("value-container").style.display === "block"
+      ) {
+        res = await fetch(`${API}/${variationId}/options`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ label: name, value }),
+        });
+      } else if (variationId) {
+        res = await fetch(`${API}/${variationId}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name }),
+        });
+      } else {
+        res = await fetch(API, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name }),
+        });
+      }
+
+      if (!res.ok) throw new Error("error saving variation");
+      closeModal();
+      fetchVariations();
+    } catch (err) {
+      alert(err.message);
+    }
+  });
+
+  async function deleteVariation(id) {
+    if (!confirm("Are you sure you want to delete this variation?")) return;
+    await fetch(`${API}/${id}`, { method: "DELETE" });
+    fetchVariations();
+  }
+
+  async function deleteOption(variationId, optionId) {
+    if (!confirm("Are you sure you want to delete this option?")) return;
+    await fetch(`${API}/${variationId}/options/${optionId}`, {
+      method: "DELETE",
+    });
+    fetchVariations();
+  }
+
+  fetchVariations();
+</script>
+{{ end }}

--- a/pkg/app/ecomm/variations/api/core/core_create.go
+++ b/pkg/app/ecomm/variations/api/core/core_create.go
@@ -1,0 +1,27 @@
+package core
+
+import (
+	"strings"
+
+	"github.com/amorindev/go-tmpl/pkg/shared/domain"
+)
+
+type CreateVariationReq struct {
+	Name string `json:"name"`
+}
+
+func (v CreateVariationReq) Validate() error {
+	if strings.TrimSpace(v.Name) == "" {
+		return domain.NewAppError(domain.ErrCodeInvalidParams, "name is required")
+	}
+	return nil
+}
+
+type CreateVarOptionReq struct {
+	Label string  `json:"label"`
+	Value *string `json:"value"`
+}
+
+func (vO CreateVarOptionReq) Validate() error {
+	return validateVarOptionFields(vO.Label, vO.Value)
+}

--- a/pkg/app/ecomm/variations/api/core/core_update.go
+++ b/pkg/app/ecomm/variations/api/core/core_update.go
@@ -1,0 +1,27 @@
+package core
+
+import (
+	"strings"
+
+	"github.com/amorindev/go-tmpl/pkg/shared/domain"
+)
+
+type UpdateVariationReq struct {
+	Name string `json:"name"`
+}
+
+func (v UpdateVariationReq) Validate() error {
+	if strings.TrimSpace(v.Name) == "" {
+		return domain.NewAppError(domain.ErrCodeInvalidParams, "name is required")
+	}
+	return nil
+}
+
+type UpdateVarOptionReq struct {
+	Label string  `json:"label"`
+	Value *string `json:"value"`
+}
+
+func (vO UpdateVarOptionReq) Validate() error{
+    return validateVarOptionFields(vO.Label,vO.Value)
+}

--- a/pkg/app/ecomm/variations/api/core/validate.go
+++ b/pkg/app/ecomm/variations/api/core/validate.go
@@ -1,0 +1,18 @@
+package core
+
+import (
+	"strings"
+
+	"github.com/amorindev/go-tmpl/pkg/shared/domain"
+)
+
+// ValidateCreate checks the fields required for creating a varOption
+func validateVarOptionFields(label string, value *string) error {
+	if strings.TrimSpace(label) == "" {
+		return domain.NewAppError(domain.ErrCodeInvalidParams, "label is required")
+	}
+	if value != nil && strings.TrimSpace(*value) == "" {
+		return domain.NewAppError(domain.ErrCodeInvalidParams, "value is required")
+	}
+	return nil
+}

--- a/pkg/app/ecomm/variations/api/handler/create_var_option.go
+++ b/pkg/app/ecomm/variations/api/handler/create_var_option.go
@@ -1,0 +1,50 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/amorindev/go-tmpl/pkg/app/ecomm/variations/api/core"
+	"github.com/amorindev/go-tmpl/pkg/app/ecomm/variations/domain"
+	cShared "github.com/amorindev/go-tmpl/pkg/shared/api/core"
+	dShared "github.com/amorindev/go-tmpl/pkg/shared/domain"
+)
+
+func (h Handler) CreateVarOption(w http.ResponseWriter, r *http.Request) {
+	variationID := r.PathValue("variationId")
+
+	if variationID == "" {
+		cShared.RespondError(w, dShared.NewAppError(dShared.ErrCodeInvalidParams, "missing variation id"))
+		return
+	}
+
+	var req core.CreateVarOptionReq
+
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		cShared.RespondError(w, dShared.NewAppError(dShared.ErrCodeInvalidParams, "invalid request body"))
+		return
+	}
+	defer r.Body.Close()
+
+	if err := req.Validate(); err != nil {
+		cShared.RespondError(w, err)
+		return
+	}
+
+	varOption := &domain.VarOption{
+		Label:       req.Label,
+		Value:       req.Value,
+		VariationID: variationID,
+	}
+
+	if err := h.VariationSrv.CreateVarOption(context.Background(), varOption); err != nil {
+		cShared.RespondError(w, err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(varOption)
+
+}

--- a/pkg/app/ecomm/variations/api/handler/create_variation.go
+++ b/pkg/app/ecomm/variations/api/handler/create_variation.go
@@ -1,0 +1,41 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/amorindev/go-tmpl/pkg/app/ecomm/variations/api/core"
+	"github.com/amorindev/go-tmpl/pkg/app/ecomm/variations/domain"
+	cShared "github.com/amorindev/go-tmpl/pkg/shared/api/core"
+	dShared "github.com/amorindev/go-tmpl/pkg/shared/domain"
+)
+
+func (h Handler) CreateVariation(w http.ResponseWriter, r *http.Request) {
+	var req core.CreateVariationReq
+
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		cShared.RespondError(w, dShared.NewAppError(dShared.ErrCodeInvalidParams, "invalid request body"))
+		return
+	}
+
+	defer r.Body.Close()
+
+	if err := req.Validate(); err != nil {
+		cShared.RespondError(w, err)
+		return
+	}
+
+	variation := &domain.Variation{
+		Name: req.Name,
+	}
+
+	if err := h.VariationSrv.CreateVariation(context.Background(), variation); err != nil {
+		cShared.RespondError(w, err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(variation)
+}

--- a/pkg/app/ecomm/variations/api/handler/delete_var_option.go
+++ b/pkg/app/ecomm/variations/api/handler/delete_var_option.go
@@ -1,0 +1,32 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+
+	cShared "github.com/amorindev/go-tmpl/pkg/shared/api/core"
+	dShared "github.com/amorindev/go-tmpl/pkg/shared/domain"
+)
+
+func (h Handler) DeleteVarOption(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	variationID := r.PathValue("variationId")
+
+	if id == "" {
+		cShared.RespondError(w, dShared.NewAppError(dShared.ErrCodeInvalidParams, "missing varOption id"))
+		return
+	}
+
+	if variationID == "" {
+		cShared.RespondError(w, dShared.NewAppError(dShared.ErrCodeInvalidParams, "missing variationId id"))
+		return
+	}
+
+	if err := h.VariationSrv.DeleteVarOption(context.Background(), id, variationID); err != nil {
+		cShared.RespondError(w, err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/pkg/app/ecomm/variations/api/handler/delete_variation.go
+++ b/pkg/app/ecomm/variations/api/handler/delete_variation.go
@@ -1,0 +1,26 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+
+	cShared "github.com/amorindev/go-tmpl/pkg/shared/api/core"
+	dShared "github.com/amorindev/go-tmpl/pkg/shared/domain"
+)
+
+func (h Handler) DeleteVariation(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+
+	if id == "" {
+		cShared.RespondError(w, dShared.NewAppError(dShared.ErrCodeInvalidParams, "missing variation id"))
+		return
+	}
+
+	if err := h.VariationSrv.DeleteVariation(context.Background(), id); err != nil {
+		cShared.RespondError(w, err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/pkg/app/ecomm/variations/api/handler/get_all_variations_with_options.go
+++ b/pkg/app/ecomm/variations/api/handler/get_all_variations_with_options.go
@@ -1,0 +1,20 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/amorindev/go-tmpl/pkg/shared/api/core"
+)
+
+func (h Handler) GetAllVariationsWithOptions(w http.ResponseWriter, r *http.Request) {
+	categories, err := h.VariationSrv.GetAllVariationsWithOptions(r.Context())
+	if err != nil {
+		core.RespondError(w, err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(categories)
+}

--- a/pkg/app/ecomm/variations/api/handler/handler.go
+++ b/pkg/app/ecomm/variations/api/handler/handler.go
@@ -1,0 +1,28 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/amorindev/go-tmpl/pkg/app/ecomm/variations/port"
+)
+
+type Handler struct {
+	VariationSrv port.VariationSrv
+}
+
+func NewVariationHandler(mux *http.ServeMux, variationSrv port.VariationSrv) *Handler {
+	h := &Handler{
+		VariationSrv: variationSrv,
+	}
+
+	mux.HandleFunc("POST /variations", h.CreateVariation)
+	mux.HandleFunc("GET /variations/options", h.GetAllVariationsWithOptions)
+	mux.HandleFunc("PUT /variations/{id}", h.UpdateVariation)
+	mux.HandleFunc("DELETE /variations/{id}", h.DeleteVariation)
+
+	mux.HandleFunc("POST /variations/{variationId}/options", h.CreateVarOption)
+	mux.HandleFunc("PUT /variations/{variationId}/options/{id}", h.UpdateVarOption)
+	mux.HandleFunc("DELETE /variations/{variationId}/options/{id}", h.DeleteVarOption)
+
+	return h
+}

--- a/pkg/app/ecomm/variations/api/handler/update_var_option.go
+++ b/pkg/app/ecomm/variations/api/handler/update_var_option.go
@@ -1,0 +1,56 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/amorindev/go-tmpl/pkg/app/ecomm/variations/api/core"
+	"github.com/amorindev/go-tmpl/pkg/app/ecomm/variations/domain"
+	cShared "github.com/amorindev/go-tmpl/pkg/shared/api/core"
+	dShared "github.com/amorindev/go-tmpl/pkg/shared/domain"
+)
+
+func (h Handler) UpdateVarOption(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	variationID := r.PathValue("variationId")
+
+	if id == "" {
+		cShared.RespondError(w, dShared.NewAppError(dShared.ErrCodeInvalidParams, "missing varOption id"))
+		return
+	}
+
+	if variationID == "" {
+		cShared.RespondError(w, dShared.NewAppError(dShared.ErrCodeInvalidParams, "missing variation id"))
+		return
+	}
+
+	var req core.UpdateVarOptionReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		cShared.RespondError(w, dShared.NewAppError(dShared.ErrCodeInvalidParams, "invalid request body"))
+		return
+	}
+
+	defer r.Body.Close()
+
+	if err := req.Validate(); err != nil {
+		cShared.RespondError(w, err)
+		return
+	}
+
+	varOption := &domain.VarOption{
+		ID:          id,
+		VariationID: variationID,
+		Label:       req.Label,
+		Value:       req.Value,
+	}
+
+	if err := h.VariationSrv.UpdateVarOption(context.Background(), varOption); err != nil {
+		cShared.RespondError(w, err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(varOption)
+}

--- a/pkg/app/ecomm/variations/api/handler/update_variation.go
+++ b/pkg/app/ecomm/variations/api/handler/update_variation.go
@@ -1,0 +1,50 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/amorindev/go-tmpl/pkg/app/ecomm/variations/api/core"
+	"github.com/amorindev/go-tmpl/pkg/app/ecomm/variations/domain"
+	cShared "github.com/amorindev/go-tmpl/pkg/shared/api/core"
+	dShared "github.com/amorindev/go-tmpl/pkg/shared/domain"
+)
+
+func (h Handler) UpdateVariation(w http.ResponseWriter, r *http.Request) {
+    id := r.PathValue("id")
+
+	if id == "" {
+		cShared.RespondError(w, dShared.NewAppError(dShared.ErrCodeInvalidParams, "missing category id"))
+		return
+	}
+
+    var req core.UpdateVariationReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		cShared.RespondError(w, dShared.NewAppError(dShared.ErrCodeInvalidParams, "invalid request body"))
+		return 
+	}
+
+	defer r.Body.Close()
+
+	if err := req.Validate(); err != nil {
+		cShared.RespondError(w, err)
+		return
+	}
+
+    variation := &domain.Variation{
+		Name: req.Name,
+        ID: id,
+	}
+
+	if err := h.VariationSrv.UpdateVariation(context.Background(), variation); err != nil {
+		cShared.RespondError(w, err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(variation)
+
+
+}

--- a/pkg/app/ecomm/variations/domain/domain_variation.go
+++ b/pkg/app/ecomm/variations/domain/domain_variation.go
@@ -1,0 +1,25 @@
+package domain
+
+import "time"
+
+// Variation represents a variation of a product (e.g. Color, Size).
+// bson omitempty we don’t want to insert it, but it will be useful for building from the database
+type Variation struct {
+	ID        interface{}  `json:"id" bson:"_id" `
+	Name      string       `json:"name" bson:"name"`
+	CreatedAt *time.Time   `json:"created_at" bson:"created_at"`
+	UpdatedAt *time.Time   `json:"updated_at" bson:"updated_at"`
+	Options   []*VarOption `json:"options,omitempty" bson:"options,omitempty"`
+}
+
+// Option represents each option inside a variation
+// e.g. "Black" "#000000"
+// e.g. "XL" nil
+type VarOption struct {
+	ID          interface{} `json:"id" bson:"_id"`
+	VariationID interface{} `json:"variation_id" bson:"variation_id"`
+	Label       string      `json:"label" bson:"label"`
+	Value       *string     `json:"value" bson:"value"`
+	CreatedAt   *time.Time  `json:"created_at" bson:"created_at"`
+	UpdatedAt   *time.Time  `json:"updated_at" bson:"updated_at"`
+}

--- a/pkg/app/ecomm/variations/port/ports_variation.go
+++ b/pkg/app/ecomm/variations/port/ports_variation.go
@@ -1,0 +1,31 @@
+package port
+
+import (
+	"context"
+
+	"github.com/amorindev/go-tmpl/pkg/app/ecomm/variations/domain"
+)
+
+type VariationRepo interface {
+	Insert(ctx context.Context, variation *domain.Variation) error
+	FindAllWithOptions(ctx context.Context) ([]*domain.Variation, error)
+	Update(ctx context.Context, variation *domain.Variation) error
+	Delete(ctx context.Context, id string) error
+}
+
+type VarOptionRepo interface {
+	Insert(ctx context.Context, varOption *domain.VarOption) error
+	Update(ctx context.Context, varOption *domain.VarOption) error
+	Delete(ctx context.Context, id string, variationID string) error
+}
+
+type VariationSrv interface {
+	CreateVariation(ctx context.Context, variation *domain.Variation) error
+	GetAllVariationsWithOptions(ctx context.Context) ([]*domain.Variation, error)
+	UpdateVariation(ctx context.Context, variation *domain.Variation) error
+	DeleteVariation(ctx context.Context, id string) error
+
+	CreateVarOption(ctx context.Context, varOption *domain.VarOption) error
+	UpdateVarOption(ctx context.Context, varOption *domain.VarOption) error
+	DeleteVarOption(ctx context.Context, id string, variationID string) error
+}

--- a/pkg/app/ecomm/variations/repository/var-option/mongo/delete.go
+++ b/pkg/app/ecomm/variations/repository/var-option/mongo/delete.go
@@ -1,0 +1,38 @@
+package mongo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/amorindev/go-tmpl/pkg/shared/domain"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+func (r *Repository) Delete(ctx context.Context, id string, variationID string) error {
+    oID, err := bson.ObjectIDFromHex(id)
+	if err != nil {
+		return domain.ErrIncorrectID
+	}
+
+    variationOID, err := bson.ObjectIDFromHex(variationID)
+	if err != nil {
+		return domain.ErrIncorrectID
+	}
+
+    filter := bson.M{
+        "_id":oID,
+        "variation_id": variationOID,
+    }
+
+    result, err := r.Collection.DeleteOne(ctx, filter)
+	if err != nil {
+		return fmt.Errorf("error deleting varOption: %w", err)
+	}
+
+    if result.DeletedCount == 0 {
+        return domain.ErrNotFound
+    }
+
+    return nil
+}
+

--- a/pkg/app/ecomm/variations/repository/var-option/mongo/insert.go
+++ b/pkg/app/ecomm/variations/repository/var-option/mongo/insert.go
@@ -1,0 +1,35 @@
+package mongo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/amorindev/go-tmpl/pkg/app/ecomm/variations/domain"
+	dShared "github.com/amorindev/go-tmpl/pkg/shared/domain"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+)
+
+func (r *Repository) Insert(ctx context.Context, varOption *domain.VarOption) error {
+	id := bson.NewObjectID()
+	varOption.ID = id
+
+	variationOID, err := bson.ObjectIDFromHex(varOption.VariationID.(string))
+	if err != nil {
+		return dShared.ErrIncorrectID
+	}
+	varOption.VariationID = variationOID
+
+	_, err = r.Collection.InsertOne(ctx, varOption)
+	if err != nil {
+		if mongo.IsDuplicateKeyError(err) {
+			return fmt.Errorf("%w: error inserting varOption: %s", dShared.ErrDuplicateKey, err.Error())
+		}
+		return fmt.Errorf("error inserting varOption: %s", err.Error())
+	}
+
+	varOption.ID = id.Hex()
+	varOption.VariationID = variationOID.Hex()
+
+	return nil
+}

--- a/pkg/app/ecomm/variations/repository/var-option/mongo/repository.go
+++ b/pkg/app/ecomm/variations/repository/var-option/mongo/repository.go
@@ -1,0 +1,20 @@
+package mongo
+
+import (
+	"github.com/amorindev/go-tmpl/pkg/app/ecomm/variations/port"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+)
+
+var _ port.VarOptionRepo = &Repository{}
+
+type Repository struct {
+	Client     *mongo.Client
+	Collection *mongo.Collection
+}
+
+func NewVarOptionRepo(client *mongo.Client, collection *mongo.Collection) *Repository {
+	return &Repository{
+		Client:     client,
+		Collection: collection,
+	}
+}

--- a/pkg/app/ecomm/variations/repository/var-option/mongo/update.go
+++ b/pkg/app/ecomm/variations/repository/var-option/mongo/update.go
@@ -1,0 +1,51 @@
+package mongo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/amorindev/go-tmpl/pkg/app/ecomm/variations/domain"
+	dShared "github.com/amorindev/go-tmpl/pkg/shared/domain"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+)
+
+func (r *Repository) Update(ctx context.Context, varOption *domain.VarOption) error {
+	oID, err := bson.ObjectIDFromHex(varOption.ID.(string))
+	if err != nil {
+		return dShared.ErrIncorrectID
+	}
+
+	variationOID, err := bson.ObjectIDFromHex(varOption.VariationID.(string))
+	if err != nil {
+		return dShared.ErrIncorrectID
+	}
+
+	update := bson.M{
+		"$set": bson.M{
+			"label":      varOption.Label,
+			"value":      varOption.Value,
+			"updated_at": varOption.UpdatedAt,
+		},
+	}
+
+	filter := bson.M{
+		"_id":          oID,
+		"variation_id": variationOID,
+	}
+
+	opts := options.FindOneAndUpdate().SetReturnDocument(options.After)
+
+	err = r.Collection.FindOneAndUpdate(ctx, filter, update, opts).Decode(&varOption)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			return dShared.ErrNotFound
+		}
+		return fmt.Errorf("failed to update varOption: %w", err)
+	}
+	varOption.ID = oID.Hex()
+	varOption.VariationID = variationOID.Hex()
+
+	return nil
+}

--- a/pkg/app/ecomm/variations/repository/variation/mongo/delete.go
+++ b/pkg/app/ecomm/variations/repository/variation/mongo/delete.go
@@ -1,0 +1,27 @@
+package mongo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/amorindev/go-tmpl/pkg/shared/domain"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+func (r *Repository) Delete(ctx context.Context, id string) error {
+	oID, err := bson.ObjectIDFromHex(id)
+	if err != nil {
+		return domain.ErrIncorrectID
+	}
+
+	result, err := r.Collection.DeleteOne(ctx, bson.M{"_id": oID})
+	if err != nil {
+		return fmt.Errorf("error deleting variation: %w", err)
+	}
+
+	if result.DeletedCount == 0 {
+        return domain.ErrNotFound
+    }
+
+	return nil
+}

--- a/pkg/app/ecomm/variations/repository/variation/mongo/find_all_with_options.go
+++ b/pkg/app/ecomm/variations/repository/variation/mongo/find_all_with_options.go
@@ -1,0 +1,39 @@
+package mongo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/amorindev/go-tmpl/pkg/app/ecomm/variations/domain"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+)
+
+func (r *Repository) FindAllWithOptions(ctx context.Context) ([]*domain.Variation, error) {
+	pipeline := mongo.Pipeline{
+		{{Key: "$lookup", Value: bson.D{
+			{Key: "from", Value: "var_options"},
+			{Key: "localField", Value: "_id"},
+			{Key: "foreignField", Value: "variation_id"},
+			{Key: "as", Value: "options"},
+		}}},
+	}
+
+	cursor, err := r.Collection.Aggregate(ctx, pipeline)
+	if err != nil {
+		return nil, fmt.Errorf("error getting variations with options: %w", err)
+	}
+	defer cursor.Close(ctx)
+
+	var variations []*domain.Variation
+	for cursor.Next(ctx) {
+		var variation domain.Variation
+		err := cursor.Decode(&variation)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding variation: %w", err)
+		}
+		variations = append(variations, &variation)
+	}
+
+	return variations, nil
+}

--- a/pkg/app/ecomm/variations/repository/variation/mongo/insert.go
+++ b/pkg/app/ecomm/variations/repository/variation/mongo/insert.go
@@ -1,0 +1,28 @@
+package mongo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/amorindev/go-tmpl/pkg/app/ecomm/variations/domain"
+	dShared "github.com/amorindev/go-tmpl/pkg/shared/domain"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+)
+
+func (r *Repository) Insert(ctx context.Context, variation *domain.Variation) error {
+	id := bson.NewObjectID()
+	variation.ID = id
+
+	_, err := r.Collection.InsertOne(ctx, variation)
+	if err != nil {
+		if mongo.IsDuplicateKeyError(err) {
+			return fmt.Errorf("%w: error inserting variation: %s", dShared.ErrDuplicateKey, err.Error())
+		}
+		return fmt.Errorf("error inserting variation: %s", err.Error())
+	}
+
+	variation.ID = id.Hex()
+
+	return nil
+}

--- a/pkg/app/ecomm/variations/repository/variation/mongo/repository.go
+++ b/pkg/app/ecomm/variations/repository/variation/mongo/repository.go
@@ -1,0 +1,20 @@
+package mongo
+
+import (
+	"github.com/amorindev/go-tmpl/pkg/app/ecomm/variations/port"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+)
+
+var _ port.VariationRepo = &Repository{}
+
+type Repository struct {
+	Client     *mongo.Client
+	Collection *mongo.Collection
+}
+
+func NewVariationRepo(client *mongo.Client, collection *mongo.Collection) *Repository {
+	return &Repository{
+		Client:     client,
+		Collection: collection,
+	}
+}

--- a/pkg/app/ecomm/variations/repository/variation/mongo/update.go
+++ b/pkg/app/ecomm/variations/repository/variation/mongo/update.go
@@ -1,0 +1,44 @@
+package mongo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/amorindev/go-tmpl/pkg/app/ecomm/variations/domain"
+	dShared "github.com/amorindev/go-tmpl/pkg/shared/domain"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+)
+
+func (r *Repository) Update(ctx context.Context, variation *domain.Variation) error {
+	oID, err := bson.ObjectIDFromHex(variation.ID.(string))
+	if err != nil {
+		return dShared.ErrIncorrectID
+	}
+
+	update := bson.M{
+		"$set": bson.M{
+			"name":       variation.Name,
+			"updated_at": variation.UpdatedAt,
+		},
+	}
+
+	filter := bson.M{
+		"_id": oID,
+	}
+
+	opts := options.FindOneAndUpdate().SetReturnDocument(options.After)
+
+	err = r.Collection.FindOneAndUpdate(ctx, filter, update, opts).Decode(variation)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			return dShared.ErrNotFound
+		}
+		return fmt.Errorf("failed to update variation: %w", err)
+	}
+
+	variation.ID = oID.Hex()
+
+	return nil
+}

--- a/pkg/app/ecomm/variations/service/create_var_option.go
+++ b/pkg/app/ecomm/variations/service/create_var_option.go
@@ -1,0 +1,22 @@
+package service
+
+import (
+	"context"
+	"time"
+
+	dShared "github.com/amorindev/go-tmpl/pkg/shared/domain"
+	"github.com/amorindev/go-tmpl/pkg/app/ecomm/variations/domain"
+)
+
+func (s *Service) CreateVarOption(ctx context.Context, varOption *domain.VarOption) error {
+	now := time.Now().UTC()
+	varOption.CreatedAt = &now
+
+	err := s.VarOptionRepo.Insert(ctx,varOption)
+    if err != nil {
+      return dShared.ManageError(err, "")
+    }
+
+	return nil
+}
+

--- a/pkg/app/ecomm/variations/service/create_variation.go
+++ b/pkg/app/ecomm/variations/service/create_variation.go
@@ -1,0 +1,21 @@
+package service
+
+import (
+	"context"
+	"time"
+
+	"github.com/amorindev/go-tmpl/pkg/app/ecomm/variations/domain"
+	dShared "github.com/amorindev/go-tmpl/pkg/shared/domain"
+)
+
+func (s *Service) CreateVariation(ctx context.Context, variation *domain.Variation) error {
+	now := time.Now().UTC()
+	variation.CreatedAt = &now
+
+	err := s.VariationRepo.Insert(ctx, variation)
+	if err != nil {
+		return dShared.ManageError(err, "")
+	}
+
+	return nil
+}

--- a/pkg/app/ecomm/variations/service/delete_var_option.go
+++ b/pkg/app/ecomm/variations/service/delete_var_option.go
@@ -1,0 +1,15 @@
+package service
+
+import (
+	"context"
+
+	"github.com/amorindev/go-tmpl/pkg/shared/domain"
+)
+
+func (s *Service) DeleteVarOption(ctx context.Context, id string, variationID string) error {
+	err := s.VarOptionRepo.Delete(ctx, id, variationID)
+	if err != nil {
+		return domain.ManageError(err, "")
+	}
+	return nil
+}

--- a/pkg/app/ecomm/variations/service/delete_variation.go
+++ b/pkg/app/ecomm/variations/service/delete_variation.go
@@ -1,0 +1,15 @@
+package service
+
+import (
+	"context"
+
+	"github.com/amorindev/go-tmpl/pkg/shared/domain"
+)
+
+func (s *Service) DeleteVariation(ctx context.Context, id string) error {
+	err := s.VariationRepo.Delete(ctx, id)
+	if err != nil {
+		return domain.ManageError(err, "")
+	}
+	return nil
+}

--- a/pkg/app/ecomm/variations/service/get_all_variations_with_options.go
+++ b/pkg/app/ecomm/variations/service/get_all_variations_with_options.go
@@ -1,0 +1,16 @@
+package service
+
+import (
+	"context"
+
+	dShared "github.com/amorindev/go-tmpl/pkg/shared/domain"
+	"github.com/amorindev/go-tmpl/pkg/app/ecomm/variations/domain"
+)
+
+func (s *Service) GetAllVariationsWithOptions(ctx context.Context) ([]*domain.Variation, error) {
+	variations, err := s.VariationRepo.FindAllWithOptions(ctx)
+	if err != nil {
+		return nil, dShared.ManageError(err, "")
+	}
+    return variations, nil
+}

--- a/pkg/app/ecomm/variations/service/service.go
+++ b/pkg/app/ecomm/variations/service/service.go
@@ -1,0 +1,17 @@
+package service
+
+import "github.com/amorindev/go-tmpl/pkg/app/ecomm/variations/port"
+
+var _ port.VariationSrv = &Service{}
+
+type Service struct {
+	VariationRepo port.VariationRepo
+    VarOptionRepo port.VarOptionRepo
+}
+
+func NewVariationSrv(variationRepo port.VariationRepo, varOptionRepo port.VarOptionRepo) *Service {
+	return &Service{
+        VariationRepo: variationRepo,
+        VarOptionRepo: varOptionRepo,
+	}
+}

--- a/pkg/app/ecomm/variations/service/update_var_option.go
+++ b/pkg/app/ecomm/variations/service/update_var_option.go
@@ -1,0 +1,21 @@
+package service
+
+import (
+	"context"
+	"time"
+
+	dShared "github.com/amorindev/go-tmpl/pkg/shared/domain"
+	"github.com/amorindev/go-tmpl/pkg/app/ecomm/variations/domain"
+)
+
+func (s *Service) UpdateVarOption(ctx context.Context,  varOption *domain.VarOption) error {
+	now := time.Now().UTC()
+	varOption.UpdatedAt = &now
+
+	err := s.VarOptionRepo.Update(ctx, varOption)
+	if err != nil {
+		return dShared.ManageError(err, "")
+	}
+    return nil
+}
+

--- a/pkg/app/ecomm/variations/service/update_variation.go
+++ b/pkg/app/ecomm/variations/service/update_variation.go
@@ -1,0 +1,21 @@
+package service
+
+import (
+	"context"
+	"time"
+
+	dShared "github.com/amorindev/go-tmpl/pkg/shared/domain"
+	"github.com/amorindev/go-tmpl/pkg/app/ecomm/variations/domain"
+)
+
+func (s *Service) UpdateVariation(ctx context.Context, variation *domain.Variation) error {
+	now := time.Now().UTC()
+	variation.UpdatedAt = &now
+
+	err := s.VariationRepo.Update(ctx, variation)
+	if err != nil {
+		return dShared.ManageError(err, "")
+	}
+    return nil
+}
+


### PR DESCRIPTION
### Description
This PR introduces a complete CRUD implementation for product variations and their options within the e-commerce module.

### Tasks:
Backend
- Added domain models for Variation and VarOption.
- Defined ports for repositories and services.
- Implemented MongoDB repositories for variations and variation options (insert, update, delete, findAllWithOptions).
- Created services with timestamps and validation logic.
Added HTTP handlers for:
- POST /variations → Create a variation
- PUT /variations/{id} → Update a variation
- DELETE /variations/{id} → Delete a variation
- GET /variations/options → Get all variations with their options
- POST /variations/{variationId}/options → Create a variation option
- PUT /variations/{variationId}/options/{id} → Update a variation option
- DELETE /variations/{variationId}/options/{id} → Delete a variation option

Consistent error handling using shared domain errors.

Admin Panel (UI)
- Sidebar: Added a new “Variations” navigation item.
- Page: Added Variations CRUD page to manage variations and their options.

<img width="886" height="446" alt="image" src="https://github.com/user-attachments/assets/9be751dc-361f-4e27-ae9b-2b8681f5e961" />

Close #3 