### PR TITLE
Feat #5 (products): add create, list, and delete endpoints with variant support

### DIFF
--- a/pkg/app/admin/api/handler/handler.go
+++ b/pkg/app/admin/api/handler/handler.go
@@ -17,6 +17,7 @@ func NewAdminHandler(mux *http.ServeMux, apiBaseUrl string) *Handler {
 	//mux.HandleFunc("/admin/other", h.OtherPage)
 	mux.HandleFunc("/admin/categories", h.CategoriesPage)
 	mux.HandleFunc("/admin/variations", h.VariationsPage)
+	mux.HandleFunc("/admin/products", h.ProductsPage)
 
 	return h
 }

--- a/pkg/app/admin/api/handler/product.page.go
+++ b/pkg/app/admin/api/handler/product.page.go
@@ -1,0 +1,32 @@
+package handler
+
+import (
+	"html/template"
+	"net/http"
+)
+
+func (h *Handler) ProductsPage(w http.ResponseWriter, r *http.Request) {
+	files := []string{
+		"pkg/app/admin/api/web/templates/base.html",
+		"pkg/app/admin/api/web/templates/products.html",
+	}
+
+	ts, err := template.ParseFiles(files...)
+	if err != nil {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	data := struct {
+		ApiBaseUrl string
+		ActivePage string
+	}{
+		ApiBaseUrl: h.ApiBaseUrl,
+		ActivePage: "product",
+	}
+
+	err = ts.ExecuteTemplate(w, "base", data)
+	if err != nil {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+	}
+}

--- a/pkg/app/admin/api/web/templates/base.html
+++ b/pkg/app/admin/api/web/templates/base.html
@@ -99,6 +99,7 @@
           <!-- <a href="/v1/admin/other" class="{{if eq .ActivePage "other"}}active{{end}}">Other</a> -->
           <a href="/v1/admin/categories" class="{{if eq .ActivePage "category"}}active{{end}}">Category</a>
           <a href="/v1/admin/variations" class="{{if eq .ActivePage "variation"}}active{{end}}">Variations</a>
+          <a href="/v1/admin/products" class="{{if eq .ActivePage "product"}}active{{end}}">Products</a>
         </nav>
       </div>
       <div class="main">

--- a/pkg/app/admin/api/web/templates/products.html
+++ b/pkg/app/admin/api/web/templates/products.html
@@ -1,0 +1,603 @@
+{{ define "title"}}Products{{end}} {{ define "content"}}
+
+<style>
+  body {
+    font-family: Arial, sans-serif;
+    background: #f7f8fa;
+    color: #1f2937;
+  }
+
+  button {
+    cursor: pointer;
+    border: none;
+    border-radius: 6px;
+    padding: 6px 12px;
+    background: #3b82f6;
+    color: white;
+    font-size: 0.9rem;
+    transition: 0.2s;
+  }
+
+  button:hover {
+    background: #2563eb;
+  }
+
+  .modal {
+    display: none;
+    position: fixed;
+    z-index: 999;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+    background: rgba(0, 0, 0, 0.4);
+  }
+
+  .modal-content {
+    background: white;
+    margin: 3% auto;
+    padding: 25px;
+    border-radius: 12px;
+    width: 80%;
+    max-width: 900px;
+    max-height: 90%;
+    overflow-y: auto;
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
+    animation: slideDown 0.3s ease-out;
+  }
+
+  @keyframes slideDown {
+    from {
+      transform: translateY(-20px);
+      opacity: 0;
+    }
+    to {
+      transform: translateY(0);
+      opacity: 1;
+    }
+  }
+
+  .modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 15px;
+    border-bottom: 1px solid #e5e7eb;
+    padding-bottom: 8px;
+  }
+
+  label {
+    display: block;
+    margin-top: 12px;
+    font-weight: bold;
+  }
+
+  input[type="text"],
+  input[type="number"],
+  textarea,
+  select {
+    width: 100%;
+    padding: 8px;
+    margin-top: 4px;
+    border: 1px solid #d1d5db;
+    border-radius: 6px;
+    font-size: 0.9rem;
+  }
+
+  textarea {
+    resize: vertical;
+    min-height: 60px;
+  }
+
+  table#products {
+    margin-top: 1.5rem;
+    border-collapse: collapse;
+    width: 100%;
+    background: white;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15);
+    border-radius: 8px;
+    overflow: hidden;
+  }
+
+  table#products th,
+  table#products td {
+    border-bottom: 1px solid #e5e7eb;
+    padding: 10px 12px;
+  }
+
+  table#products th {
+    background: #f3f4f6;
+    text-align: left;
+    font-weight: 600;
+  }
+
+  table#products tr:nth-child(even) {
+    background: #f9fafb;
+  }
+
+  table#products tr:hover {
+    background: #e5e7eb;
+  }
+
+  .hidden {
+    display: none;
+  }
+
+  #msg {
+    margin-bottom: 12px;
+    font-weight: 500;
+  }
+
+  #productForm button[type="submit"] {
+    margin-right: 8px;
+    background: #10b981;
+  }
+
+  #productForm button[type="submit"]:hover {
+    background: #059669;
+  }
+
+  #productForm button[type="button"] {
+    background: #ef4444;
+  }
+
+  #productForm button[type="button"]:hover {
+    background: #b91c1c;
+  }
+
+  #items table,
+  #items th,
+  #items td {
+    border: 1px solid #d1d5db;
+    border-radius: 6px;
+    overflow: hidden;
+  }
+
+  #items th,
+  #items td {
+    padding: 6px 8px;
+    font-size: 0.9rem;
+  }
+
+  #imgModal .modal-content {
+    padding: 15px;
+    border-radius: 10px;
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
+  }
+
+  input[type="file"] {
+    padding: 3px;
+  }
+</style>
+
+<div id="msg"></div>
+<button onclick="openProductModal()">➕ Add Product</button>
+
+<!-- Modal -->
+<div id="productModal" class="modal">
+  <div class="modal-content">
+    <div class="modal-header">
+      <h3 id="modal-title">Add Product</h3>
+      <button onclick="closeProductModal()">❌</button>
+    </div>
+
+    <form id="productForm" enctype="multipart/form-data">
+      <input type="hidden" id="prod-id" name="id" />
+
+      <label>Name:</label>
+      <input type="text" name="name" id="prod-name" required />
+
+      <label>Description:</label>
+      <textarea name="desc" id="prod-desc"></textarea>
+
+      <label>Category:</label>
+      <select name="category_id" id="categorySelect"></select>
+
+      <label>Main Image:</label>
+      <input type="file" name="main_image" id="prod-img" />
+
+      <!-- Toggle: Product Type -->
+      <label
+        ><input type="radio" name="has_variants" value="false" checked />
+        Product without variants</label
+      >
+      <label
+        ><input type="radio" name="has_variants" value="true" /> Product with
+        variants</label
+      >
+
+      <!-- Single Item Fields -->
+      <div id="single-item-fields">
+        <label>Price:</label>
+        <input
+          type="number"
+          step="0.01"
+          name="item_price"
+          id="single-price"
+          required
+        />
+        <label>Stock Quantity:</label>
+        <input type="number" name="item_qty" id="single-qty" required />
+      </div>
+
+      <!-- Variations -->
+      <div id="variants-fields" class="hidden">
+        <h3>Variations</h3>
+        <div id="variationContainer"></div>
+        <button type="button" onclick="addVariation()">Add Variation</button>
+      </div>
+
+      <!-- Items Table (only for variants) -->
+      <div id="items"></div>
+
+      <br />
+      <button type="submit">Save Product</button>
+      <button type="button" onclick="closeProductModal()">Cancel</button>
+    </form>
+  </div>
+</div>
+
+<!-- Products Table -->
+<table id="products">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Category</th>
+      <th>Image</th>
+      <th>Items</th>
+      <th>Created</th>
+      <th>Updated</th>
+      <th>Actions</th>
+    </tr>
+  </thead>
+  <tbody></tbody>
+</table>
+
+<!-- Image Modal -->
+<div id="imgModal" class="modal" onclick="closeImgModal()">
+  <div class="modal-content" style="max-width: 600px; text-align: center">
+    <img
+      id="imgPreview"
+      src=""
+      alt="Product"
+      style="max-width: 100%; border-radius: 8px"
+    />
+  </div>
+</div>
+
+<script>
+  let variationsData = [];
+
+  const API_PRODUCTS = "http://localhost:8000/v1/products";
+  const API_CATEGORIES = "http://localhost:8000/v1/categories";
+  const API_VARIATIONS = "http://localhost:8000/v1/variations/options";
+
+  // Modal controls
+  function openProductModal(id = "", name = "", desc = "", category_id = "") {
+    document.getElementById("modal-title").textContent = id
+      ? "Update Product"
+      : "Add Product";
+    document.getElementById("prod-id").value = id;
+    document.getElementById("prod-name").value = name;
+    document.getElementById("prod-desc").value = desc;
+    document.getElementById("categorySelect").value = category_id || "";
+    document.getElementById("productModal").style.display = "block";
+
+    document.querySelector(
+      "input[name='has_variants'][value='false']"
+    ).checked = true;
+    toggleProductType();
+  }
+
+  function closeProductModal() {
+    document.getElementById("productModal").style.display = "none";
+    document.getElementById("productForm").reset();
+    document.getElementById("variationContainer").innerHTML = "";
+    document.getElementById("items").innerHTML = "";
+  }
+
+  async function loadCategories() {
+    try {
+      const res = await fetch(API_CATEGORIES);
+      if (!res.ok) throw new Error("Error loading categories");
+
+      const categories = await res.json();
+      const select = document.getElementById("categorySelect");
+      select.innerHTML = "<option value=''>-- select --</option>";
+
+      categories.forEach((cat) => {
+        const opt = document.createElement("option");
+        opt.value = cat.id;
+        opt.textContent = cat.name;
+        select.appendChild(opt);
+      });
+    } catch (err) {
+      alert(err.message);
+    }
+  }
+
+  async function loadVariations() {
+    try {
+      const res = await fetch(API_VARIATIONS);
+      if (!res.ok) throw new Error("Error loading variations");
+      variationsData = await res.json();
+    } catch (err) {
+      alert(err.message);
+    }
+  }
+
+  function toggleProductType() {
+    const hasVariants =
+      document.querySelector("input[name='has_variants']:checked").value ===
+      "true";
+    document
+      .getElementById("single-item-fields")
+      .classList.toggle("hidden", hasVariants);
+    document
+      .getElementById("variants-fields")
+      .classList.toggle("hidden", !hasVariants);
+
+    if (!hasVariants) document.getElementById("items").innerHTML = "";
+  }
+
+  document
+    .querySelectorAll("input[name='has_variants']")
+    .forEach((r) => r.addEventListener("change", toggleProductType));
+
+  function addVariation() {
+    const container = document.getElementById("variationContainer");
+    const div = document.createElement("div");
+    let html = `<label>Select Variation:</label>
+              <select class="variationSelect">
+                <option value="">-- select --</option>`;
+    variationsData.forEach(
+      (v) => (html += `<option value="${v.id}">${v.name}</option>`)
+    );
+    html += `</select>
+           <div class="optionsBox"></div><br>`;
+    div.innerHTML = html;
+    container.appendChild(div);
+
+    div
+      .querySelector(".variationSelect")
+      .addEventListener("change", function () {
+        const variationId = this.value;
+        const variation = variationsData.find((v) => v.id === variationId);
+        const optionsBox = div.querySelector(".optionsBox");
+        optionsBox.innerHTML = "";
+        if (variation && variation.options) {
+          variation.options.forEach((opt) => {
+            optionsBox.innerHTML += `<label>
+          <input type="checkbox" data-variation="${variation.id}" value="${opt.id}" data-label="${opt.label}">${opt.label}
+        </label><br>`;
+          });
+        }
+        optionsBox.addEventListener("change", generateCombinations);
+      });
+  }
+
+  function generateCombinations() {
+    const selected = {};
+    document.querySelectorAll(".optionsBox").forEach((box) => {
+      box.querySelectorAll("input[type=checkbox]:checked").forEach((cb) => {
+        const vid = cb.dataset.variation;
+        if (!selected[vid]) selected[vid] = [];
+        selected[vid].push({ id: cb.value, label: cb.dataset.label });
+      });
+    });
+
+    const itemsDiv = document.getElementById("items");
+    itemsDiv.innerHTML = "";
+    if (Object.keys(selected).length === 0) return;
+
+    let combos = [[]];
+    for (let vId in selected) {
+      let opts = selected[vId];
+      let newCombos = [];
+      combos.forEach((c) => opts.forEach((opt) => newCombos.push([...c, opt])));
+      combos = newCombos;
+    }
+
+    let html = `<h3>Items</h3><table border="1" cellpadding="5"><thead><tr><th>Combination</th><th>Image</th><th>Price</th><th>Stock</th></tr></thead><tbody>`;
+    combos.forEach((combo, i) => {
+      const comboLabel = combo.map((c) => c.label).join(" / ");
+      const comboIds = combo.map((c) => c.id).join(",");
+      html += `<tr>
+      <td>${comboLabel}</td>
+      <td><input type="file" name="item_image_${i}"></td>
+      <td><input type="number" step="0.01" name="item_price_${i}" required></td>
+      <td><input type="number" name="item_qty_${i}" required></td>
+      <input type="hidden" name="item_options_${i}" value="${comboIds}">
+    </tr>`;
+    });
+    html += `</tbody></table>`;
+    itemsDiv.innerHTML = html;
+  }
+
+  function toggleProductType() {
+    const hasVariants =
+      document.querySelector("input[name='has_variants']:checked").value ===
+      "true";
+
+    const singleFields = document.getElementById("single-item-fields");
+    const variantFields = document.getElementById("variants-fields");
+
+    singleFields.classList.toggle("hidden", hasVariants);
+    variantFields.classList.toggle("hidden", !hasVariants);
+
+    // Habilitar/deshabilitar required
+    singleFields.querySelectorAll("input").forEach((inp) => {
+      if (hasVariants) inp.removeAttribute("required");
+      else inp.setAttribute("required", "true");
+    });
+
+    // Borro la tabla de items si es producto simple
+    if (!hasVariants) {
+      document.getElementById("items").innerHTML = "";
+    }
+  }
+
+  document
+    .getElementById("productForm")
+    .addEventListener("submit", async (e) => {
+      e.preventDefault();
+      try {
+        const form = e.target;
+        const formData = new FormData();
+        const hasVariants =
+          document.querySelector("input[name='has_variants']:checked").value ===
+          "true";
+
+        var desc = form.querySelector("#prod-desc").value;
+        if (desc == "") {
+          desc = null;
+        }
+
+        const product = {
+          name: form.querySelector("#prod-name").value,
+          desc: desc,
+          category_id: form.querySelector("#categorySelect").value,
+          file_path: form.querySelector("#prod-img").files[0]?.name || "",
+          product_items: [],
+        };
+
+        if (!hasVariants) {
+          product.product_items.push({
+            price: parseFloat(form.querySelector("#single-price").value),
+            qty_in_stock: parseInt(form.querySelector("#single-qty").value),
+            file_path: form.querySelector("#prod-img").files[0]?.name || "",
+            var_option_ids: [],
+          });
+          if (form.querySelector("#prod-img").files[0])
+            formData.append(
+              "item_image_0",
+              form.querySelector("#prod-img").files[0]
+            );
+        } else {
+          document
+            .querySelectorAll("#items table tbody tr")
+            .forEach((row, i) => {
+              product.product_items.push({
+                price: parseFloat(
+                  row.querySelector(`input[name=item_price_${i}]`).value
+                ),
+                qty_in_stock: parseInt(
+                  row.querySelector(`input[name=item_qty_${i}]`).value
+                ),
+                file_path:
+                  row.querySelector(`input[name=item_image_${i}]`).files[0]
+                    ?.name || "",
+                var_option_ids: row
+                  .querySelector(`input[name=item_options_${i}]`)
+                  .value.split(","),
+              });
+              const file = row.querySelector(`input[name=item_image_${i}]`)
+                .files[0];
+              if (file) formData.append(`item_image_${i}`, file);
+            });
+        }
+
+        if (form.querySelector("#prod-img").files[0])
+          formData.append(
+            "main_image",
+            form.querySelector("#prod-img").files[0]
+          );
+        formData.append("product", JSON.stringify(product));
+
+        const res = await fetch(API_PRODUCTS, {
+          method: "POST",
+          body: formData,
+        });
+        if (res.ok) {
+          alert("Product saved!");
+          loadProducts();
+          closeProductModal();
+        } else {
+          const errMsg = await res.json();
+          alert("Error saving: " + (errMsg.msg || JSON.stringify(errMsg)));
+        }
+      } catch (err) {
+        alert("Unexpected error: " + err.message);
+      }
+    });
+
+  async function deleteProduct(id) {
+    if (!confirm("Delete this product?")) return;
+    try {
+      const res = await fetch(`${API_PRODUCTS}/${id}`, { method: "DELETE" });
+      if (!res.ok) {
+        const errMsg = await res.json().catch(() => ({}));
+        throw new Error(errMsg.msg || "Error deleting product");
+      }
+      alert("Product deleted!");
+      loadProducts();
+    } catch (err) {
+      alert("Unexpected error " + err.message);
+    }
+  }
+
+  function openImgModal(url) {
+    document.getElementById("imgPreview").src = url;
+    document.getElementById("imgModal").style.display = "block";
+  }
+  function closeImgModal() {
+    document.getElementById("imgModal").style.display = "none";
+  }
+
+  async function loadProducts() {
+    const msg = document.getElementById("msg");
+    msg.textContent = "Loading...";
+    msg.style.color = "black";
+    try {
+      const res = await fetch(`${API_PRODUCTS}`);
+      if (!res.ok) throw new Error("Error getting products");
+
+      const data = await res.json();
+      const tbody = document.querySelector("#products tbody");
+      tbody.innerHTML = "";
+
+      if (
+        !data.products ||
+        !Array.isArray(data.products) ||
+        data.products.length === 0
+      ) {
+        tbody.innerHTML = `<tr><td colspan="7" style="text-align:center;">No products</td></tr>`;
+        msg.textContent = "";
+        return;
+      }
+
+      data.products.forEach((p) => {
+        const row = document.createElement("tr");
+        row.innerHTML = `
+        <td>${p.name}</td>
+        <td>${p.category_name || ""}</td>
+        <td>${
+          p.img_url
+            ? `<img src="${p.img_url}" alt="${p.name}" 
+                style="width:50px;height:50px;object-fit:cover;cursor:pointer;border-radius:6px;" 
+                onclick="openImgModal('${p.img_url}')"/>`
+            : "-"
+        }</td>
+        <td>${Array.isArray(p.product_items) ? p.product_items.length : 0}</td>
+        <td>${p.created_at}</td>
+        <td>${p.updated_at}</td>
+        <td><button onclick="deleteProduct('${p.id}')">🗑️ Delete</button></td>`;
+        tbody.appendChild(row);
+      });
+
+      msg.textContent = "";
+    } catch (err) {
+      msg.textContent = err.message;
+      msg.style.color = "red";
+    }
+  }
+
+  document.addEventListener("DOMContentLoaded", async () => {
+    await loadCategories();
+    await loadVariations();
+    await loadProducts();
+  });
+</script>
+
+{{ end }}

--- a/pkg/app/ecomm/products/api/core/core.go
+++ b/pkg/app/ecomm/products/api/core/core.go
@@ -1,0 +1,78 @@
+package core
+
+import (
+	"strings"
+
+	"github.com/amorindev/go-tmpl/pkg/shared/domain"
+)
+
+type CreateProductReq struct {
+	CategoryID string  `json:"category_id,omitempty"`
+	Name       string  `json:"name"`
+	Desc       *string `json:"desc"`
+	FilePath   string  `json:"file_path"`
+	ProductItems []*CreateProductItem `json:"product_items"`
+}
+
+type CreateProductItem struct {
+	QtyInStock   int           `json:"qty_in_stock"`
+	Price        float64       `json:"price"`
+	FilePath     string        `json:"file_path"`
+	ContentType  string        `json:"content_type"`
+	VarOptionIDs []interface{} `json:"var_option_ids,omitempty"`
+}
+
+func (c CreateProductReq) Validate() error {
+	if strings.TrimSpace(c.CategoryID) == "" {
+		return domain.NewAppError(domain.ErrCodeInvalidParams, "category_id is required")
+	}
+	if strings.TrimSpace(c.Name) == "" {
+		return domain.NewAppError(domain.ErrCodeInvalidParams, "name is required")
+	}
+	if c.Desc != nil && strings.TrimSpace(*c.Desc) == "" {
+		return domain.NewAppError(domain.ErrCodeInvalidParams, "desc is required")
+	}
+	if strings.TrimSpace(c.FilePath) == "" {
+		return domain.NewAppError(domain.ErrCodeInvalidParams, "file_path is required")
+	}
+
+	// Invalid product (no items at all)
+	if len(c.ProductItems) == 0 {
+		return domain.NewAppError(domain.ErrCodeInvalidParams, "at least one product item is required")
+	}
+
+	// Product with variants (must have at least 2 items)
+	if len(c.ProductItems) > 1 {
+		for _, item := range c.ProductItems {
+			if len(item.VarOptionIDs) == 0 {
+				return domain.NewAppError(domain.ErrCodeInvalidParams, "variant options are required for product items")
+			}
+			if strings.TrimSpace(item.FilePath) == "" {
+				return domain.NewAppError(domain.ErrCodeInvalidParams, "file_path is required for each product item")
+			}
+			if item.Price <= 0 {
+				return domain.NewAppError(domain.ErrCodeInvalidParams, "price must be greater than zero")
+			}
+			if item.QtyInStock < 0 {
+				return domain.NewAppError(domain.ErrCodeInvalidParams, "qty_in_stock cannot be negative")
+			}
+		}
+	}
+
+	// Product without variants (only 1 item, no variant options)
+	// Note: FilePath is not validated here, because it is assigned in the handler from main_image
+	if len(c.ProductItems) == 1 {
+		item := c.ProductItems[0]
+		if len(item.VarOptionIDs) > 0 {
+			return domain.NewAppError(domain.ErrCodeInvalidParams, "single product must not contain variant options")
+		}
+		if item.Price <= 0 {
+			return domain.NewAppError(domain.ErrCodeInvalidParams, "price must be greater than zero")
+		}
+		if item.QtyInStock < 0 {
+			return domain.NewAppError(domain.ErrCodeInvalidParams, "qty_in_stock cannot be negative")
+		}
+	}
+
+	return nil
+}

--- a/pkg/app/ecomm/products/api/core/core_resp.go
+++ b/pkg/app/ecomm/products/api/core/core_resp.go
@@ -1,0 +1,11 @@
+package core
+
+import "github.com/amorindev/go-tmpl/pkg/app/ecomm/products/domain"
+
+type ProductResp struct {
+	Count    int64             `json:"count"`
+	Pages    int64             `json:"pages"`
+	Next     *string           `json:"next"`
+	Previous *string           `json:"previous"`
+	Products []*domain.Product `json:"products"`
+}

--- a/pkg/app/ecomm/products/api/handler/create.go
+++ b/pkg/app/ecomm/products/api/handler/create.go
@@ -1,0 +1,151 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/amorindev/go-tmpl/pkg/app/ecomm/products/api/core"
+	"github.com/amorindev/go-tmpl/pkg/app/ecomm/products/domain"
+	cShared "github.com/amorindev/go-tmpl/pkg/shared/api/core"
+	dShared "github.com/amorindev/go-tmpl/pkg/shared/domain"
+)
+
+func (h Handler) Create(w http.ResponseWriter, r *http.Request) {
+	err := r.ParseMultipartForm(20 << 20) // 20MB
+	if err != nil {
+		cShared.RespondError(w, dShared.NewAppError(dShared.ErrCodeInvalidParams, "invalid form"))
+		return
+	}
+
+	// Get the product JSON
+	productJSON := r.FormValue("product")
+	if productJSON == "" {
+		cShared.RespondError(w, dShared.NewAppError(dShared.ErrCodeInvalidParams, "missing product json"))
+		return
+	}
+
+	var req core.CreateProductReq
+	if err := json.Unmarshal([]byte(productJSON), &req); err != nil {
+		cShared.RespondError(w, dShared.NewAppError(dShared.ErrCodeInvalidParams, "invalid product json"))
+		return
+	}
+
+	if err := req.Validate(); err != nil {
+		cShared.RespondError(w, err)
+		return
+	}
+
+	// Main image
+	files := map[string][]byte{}
+	contentTypes := map[string]string{}
+
+	if headers, ok := r.MultipartForm.File["main_image"]; ok {
+		for _, header := range headers {
+			// Try to open the uploaded file
+			file, err := header.Open()
+			if err != nil {
+				msg := fmt.Sprintf("failed to open file %s: %v", header.Filename, err)
+				cShared.RespondError(w, dShared.NewAppError(dShared.ErrCodeInvalidParams, msg))
+				return
+			}
+
+			defer file.Close()
+
+			// Read file content
+			buf, err := io.ReadAll(file)
+			if err != nil {
+				msg := fmt.Sprintf("failed to read file %s: %v", header.Filename, err)
+				cShared.RespondError(w, dShared.NewAppError(dShared.ErrCodeInternalServerError, msg))
+				return
+			}
+
+			// Store file content and content type in maps
+			files[header.Filename] = buf
+			contentTypes[header.Filename] = header.Header.Get("Content-Type")
+		}
+
+	} else {
+		cShared.RespondError(w, dShared.NewAppError(dShared.ErrCodeInvalidParams, "main_image is required"))
+		return
+	}
+
+	// Handle item images (if they exist)
+	for i := 0; i < len(req.ProductItems); i++ {
+		field := fmt.Sprintf("item_image_%d", i)
+		if headers, ok := r.MultipartForm.File[field]; ok {
+			for _, header := range headers {
+				// Try to open the uploaded item image
+				file, err := header.Open()
+				if err != nil {
+					msg := fmt.Sprintf("failed to open item image %s: %v", header.Filename, err)
+					cShared.RespondError(w, dShared.NewAppError(dShared.ErrCodeInvalidParams, msg))
+					return
+				}
+				defer file.Close()
+				buf, err := io.ReadAll(file)
+				if err != nil {
+					msg := fmt.Sprintf("failed to read item image %s: %v", header.Filename, err)
+					cShared.RespondError(w, dShared.NewAppError(dShared.ErrCodeInternalServerError, msg))
+					return
+				}
+
+				//  Store item image content and content type in maps
+				files[header.Filename] = buf
+				contentTypes[header.Filename] = header.Header.Get("Content-Type")
+			}
+		}
+	}
+
+	product := &domain.Product{
+		Name:        req.Name,
+		Desc:        req.Desc,
+		CategoryID:  req.CategoryID,
+		FilePath:    req.FilePath,
+		File:        files[req.FilePath],
+		ContentType: contentTypes[req.FilePath],
+	}
+
+	// Product with variants
+	if len(req.ProductItems) > 1 {
+		for _, it := range req.ProductItems {
+			pItem := &domain.ProductItem{
+				Price:        it.Price,
+				QtyInStock:   it.QtyInStock,
+				FilePath:     it.FilePath,
+				File:         files[it.FilePath],
+				ContentType:  contentTypes[it.FilePath],
+				VarOptionIDs: it.VarOptionIDs,
+			}
+			product.ProductItems = append(product.ProductItems, pItem)
+		}
+	} else {
+		// Product without variants -> a single item by default
+		pItem := &domain.ProductItem{
+			Price:      req.ProductItems[0].Price,
+			QtyInStock: req.ProductItems[0].QtyInStock,
+			// same as main image: file path, filename and content
+			FilePath:    req.FilePath,
+			File:        files[req.FilePath],
+			ContentType: contentTypes[req.FilePath],
+		}
+		product.ProductItems = append(product.ProductItems, pItem)
+	}
+
+	if err := h.ProductSrv.Create(context.Background(), product); err != nil {
+		cShared.RespondError(w, err)
+		return
+	}
+
+	resp := struct {
+		ID string `json:"id"`
+	}{
+		ID: product.ID.(string),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(resp)
+}

--- a/pkg/app/ecomm/products/api/handler/delete.go
+++ b/pkg/app/ecomm/products/api/handler/delete.go
@@ -1,0 +1,25 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+
+	cShared "github.com/amorindev/go-tmpl/pkg/shared/api/core"
+	dShared "github.com/amorindev/go-tmpl/pkg/shared/domain"
+)
+
+func (h Handler) Delete(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		cShared.RespondError(w, dShared.NewAppError(dShared.ErrCodeInvalidParams, "missing product id"))
+		return
+	}
+
+	if err := h.ProductSrv.Delete(context.Background(), id); err != nil {
+		cShared.RespondError(w, err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/pkg/app/ecomm/products/api/handler/get_all.go
+++ b/pkg/app/ecomm/products/api/handler/get_all.go
@@ -1,0 +1,68 @@
+package handler
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/amorindev/go-tmpl/pkg/app/ecomm/products/api/core"
+	cShared "github.com/amorindev/go-tmpl/pkg/shared/api/core"
+)
+
+func (h Handler) GetAll(w http.ResponseWriter, r *http.Request) {
+	query := r.URL.Query()
+
+	pageStr := query.Get("page")
+	limitStr := query.Get("limit")
+
+	page, err := strconv.Atoi(pageStr)
+	if err != nil {
+		page = 1
+	}
+
+	limit, err := strconv.Atoi(limitStr)
+	if err != nil || limit < 1 || limit > 100 {
+		limit = 10
+	}
+
+	products, count, totalPages, err := h.ProductSrv.GetAll(r.Context(), int64(limit), int64(page))
+	if err != nil {
+		cShared.RespondError(w, err)
+		return
+	}
+
+	// Determine request scheme
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+
+	host := r.Host
+	basePath := "/v1" + r.URL.Path
+
+	// Build pagination links
+	var nextURL *string
+	if int64(page) < totalPages {
+		url := fmt.Sprintf("%s://%s%s?page=%d&limit=%d", scheme, host, basePath, page+1, limit)
+		nextURL = &url
+	}
+
+	var prevURL *string
+	if page > 1 {
+		url := fmt.Sprintf("%s://%s%s?page=%d&limit=%d", scheme, host, basePath, page-1, limit)
+		prevURL = &url
+	}
+
+	resp := &core.ProductResp{
+		Count:    count,
+		Pages:    totalPages,
+		Next:     nextURL,
+		Previous: prevURL,
+		Products: products,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(resp)
+}

--- a/pkg/app/ecomm/products/api/handler/handler.go
+++ b/pkg/app/ecomm/products/api/handler/handler.go
@@ -1,0 +1,23 @@
+package handler
+
+import (
+	"net/http"
+
+	productP "github.com/amorindev/go-tmpl/pkg/app/ecomm/products/port"
+)
+
+type Handler struct {
+	ProductSrv productP.ProductSrv
+}
+
+func NewProductHandler(server *http.ServeMux, productSrv productP.ProductSrv) *Handler {
+	h := &Handler{
+		ProductSrv: productSrv,
+	}
+
+	server.HandleFunc("GET /products", h.GetAll)
+	server.HandleFunc("POST /products", h.Create)
+	server.HandleFunc("DELETE /products/{id}", h.Delete)
+
+	return h
+}

--- a/pkg/app/ecomm/products/domain/domain.go
+++ b/pkg/app/ecomm/products/domain/domain.go
@@ -1,0 +1,26 @@
+package domain
+
+import "time"
+
+type Product struct {
+	ID           interface{}    `json:"id" bson:"_id"`
+	CategoryID   interface{}    `json:"category_id,omitempty" bson:"category_id"`
+	Name         string         `json:"name" bson:"name"`
+	Desc         *string        `json:"desc" bson:"desc"`
+	FilePath     string         `json:"-" bson:"file_path"`
+	File         []byte         `json:"-" bson:"-"`
+	ContentType  string         `json:"-" bson:"-"`
+	ImgUrl       string         `json:"img_url" bson:"-"`
+	CategoryName string         `json:"category_name" bson:"category_name,omitempty"`
+	Status       ProductStatus  `json:"status" bson:"status"`
+	CreatedAt    *time.Time     `json:"created_at" bson:"created_at"`
+	UpdatedAt    *time.Time     `json:"updated_at" bson:"updated_at"`
+	ProductItems []*ProductItem `json:"product_items" bson:"product_items,omitempty"`
+	Variations   []*Variation   `json:"variations" bson:"-"`
+}
+
+// Only response
+type Variation struct {
+	Name   string   `json:"name"`
+	Values []string `json:"values"`
+}

--- a/pkg/app/ecomm/products/domain/domain_item.go
+++ b/pkg/app/ecomm/products/domain/domain_item.go
@@ -1,0 +1,28 @@
+package domain
+
+import "time"
+
+type ProductItem struct {
+	ID           interface{}   `json:"id" bson:"_id"`
+	Sku          string        `json:"sku" bson:"sku"`
+	QtyInStock   int           `json:"qty_in_stock" bson:"qty_in_stock"`
+	Price        float64       `json:"price" bson:"price"`
+	FilePath     string        `json:"-" bson:"file_path"`
+	File         []byte        `json:"-" bson:"-"`
+	ContentType  string        `json:"-" bson:"-"`
+	ImgUrl       string        `json:"img_url" bson:"-"`
+	CreatedAt    *time.Time    `json:"created_at" bson:"created_at"`
+	UpdatedAt    *time.Time    `json:"updated_at" bson:"updated_at"`
+	VarOptionIDs []interface{} `json:"var_option_ids,omitempty" bson:"var_option_ids"`
+	Options      []*Option     `json:"options" bson:"options,omitempty"`
+}
+
+// Option represents a specific variation choice for a product item
+// For the response, the data is built directly from the DB, that's why it includes `bson` tags.
+// Name: Color, VarOptName Blue, VarOptValue: #0000FF
+// Name: Size, VarOptName S, VarOptValue: nil
+type Option struct {
+	Name        string `json:"name" bson:"name"`
+	VarOptName  string `json:"var_opt_name" bson:"var_opt_name"`
+	VarOptValue string `json:"var_opt_value" bson:"var_opt_value"`
+}

--- a/pkg/app/ecomm/products/domain/enums.go
+++ b/pkg/app/ecomm/products/domain/enums.go
@@ -1,0 +1,9 @@
+package domain
+
+// ProductStatus defines the possible states of a product
+type ProductStatus string
+
+const (
+	ProductStatusActive   ProductStatus = "active"   // The product is available for sale
+	ProductStatusInactive ProductStatus = "inactive" // The product is not available for customers
+)

--- a/pkg/app/ecomm/products/helpers/calculate_variations.go
+++ b/pkg/app/ecomm/products/helpers/calculate_variations.go
@@ -1,0 +1,53 @@
+package helpers
+
+import (
+	"sort"
+
+	"github.com/amorindev/go-tmpl/pkg/app/ecomm/products/domain"
+)
+
+// CalculateVariations builds and assigns the list of unique product variations
+// (e.g., Color, Size, Material) based on the options defined across all ProductItems.
+//
+// Process:
+//  1. Iterate over each ProductItem and its options.
+//  2. Group option values by variation name using a map (acting as a set to avoid duplicates).
+//  3. Convert each set into a slice and sort values alphabetically for consistency.
+//  4. Assign the resulting list to p.Variations.
+//
+// Example:
+//  - ProductItems with options:
+//      Color=Red, Size=M
+//      Color=Blue, Size=L
+//  - Result in p.Variations:
+//      [
+//        {Name: "Color", Values: ["Blue", "Red"]},
+//        {Name: "Size", Values: ["L", "M"]}
+//      ]
+func CalculateVariations(p *domain.Product) {
+	variationMap := make(map[string]map[string]struct{})
+
+	for _, item := range p.ProductItems {
+		for _, opt := range item.Options {
+			if _, exists := variationMap[opt.Name]; !exists {
+				variationMap[opt.Name] = make(map[string]struct{})
+			}
+			variationMap[opt.Name][opt.VarOptName] = struct{}{}
+		}
+	}
+
+	var variations []*domain.Variation
+	for name, valuesSet := range variationMap {
+		var values []string
+		for val := range valuesSet {
+			values = append(values, val)
+		}
+		sort.Strings(values)
+		variations = append(variations, &domain.Variation{
+			Name:   name,
+			Values: values,
+		})
+	}
+
+	p.Variations = variations
+}

--- a/pkg/app/ecomm/products/helpers/generate_sku.go
+++ b/pkg/app/ecomm/products/helpers/generate_sku.go
@@ -1,0 +1,45 @@
+package helpers
+
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+	"time"
+
+	"github.com/amorindev/go-tmpl/pkg/app/ecomm/products/domain"
+)
+
+func GenerateItemSKU(p *domain.Product, item *domain.ProductItem) string {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	// Category prefix (default "CAT", otherwise first 3 chars of CategoryName)
+	categoryPart := "CAT"
+	if p.CategoryName != "" {
+		categoryPart = strings.ToUpper(p.CategoryName[:min(3, len(p.CategoryName))])
+	}
+
+	// Product name prefix (first 3 chars of product name, ignoring spaces)
+	namePart := strings.ToUpper(strings.ReplaceAll(p.Name, " ", ""))[:min(3, len(p.Name))]
+
+	// Variation options (e.g., color "RED", size "L"), take first 2 chars of each option
+	var optionPart string
+	if len(item.Options) > 0 {
+		for _, opt := range item.Options {
+			optionPart += strings.ToUpper(opt.VarOptName[:min(2, len(opt.VarOptName))])
+		}
+	}
+
+	// Random number (4 digits)
+	randomPart := fmt.Sprintf("%04d", r.Intn(10000))
+
+	// Final SKU format: CATEGORY-NAME-OPTIONS-RANDOM
+	return fmt.Sprintf("%s-%s-%s-%s", categoryPart, namePart, optionPart, randomPart)
+}
+
+// Helper function: returns the smaller of two integers
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/pkg/app/ecomm/products/logger/logger.go
+++ b/pkg/app/ecomm/products/logger/logger.go
@@ -1,0 +1,37 @@
+package logger
+
+import (
+	"fmt"
+
+	"github.com/amorindev/go-tmpl/pkg/app/ecomm/products/domain"
+)
+
+func PrintProducts(products []*domain.Product) {
+
+	for i, product := range products {
+		fmt.Printf("---------- Product %d ------------------\n", i+1)
+		fmt.Printf("Product name %v\n", product.Name)
+		fmt.Printf("Product desc %v\n", product.Desc)
+		fmt.Printf("Product category name %v\n", product.CategoryName)
+		fmt.Printf("Product filepath %v\n", product.FilePath)
+		fmt.Printf("Product file length %v\n", len(product.File))
+		fmt.Printf("Product content-type %v\n", product.ContentType)
+		fmt.Printf("Status %v\n", product.Status)
+
+		for j, pItem := range product.ProductItems {
+			fmt.Printf("---------- Product Item %d ------------------\n", j+1)
+			fmt.Printf("Qty in stock %v\n", pItem.QtyInStock)
+			fmt.Printf("Price %v\n", pItem.Price)
+			fmt.Printf("FilePath %v\n", pItem.FilePath)
+			fmt.Printf("ProductItem file length %v\n", len(pItem.File))
+
+			fmt.Printf("Content-Type %v\n", pItem.ContentType)
+			for k, option := range pItem.Options {
+				fmt.Printf("---------- Option %d ------------------\n", k+1)
+				fmt.Printf("Name %v\n", option.Name)
+				fmt.Printf("varOptionName %v\n", option.VarOptName)
+				fmt.Printf("varOptionValue %v\n", option.VarOptValue)
+			}
+		}
+	}
+}

--- a/pkg/app/ecomm/products/port/ports.go
+++ b/pkg/app/ecomm/products/port/ports.go
@@ -1,0 +1,20 @@
+package port
+
+import (
+	"context"
+
+	"github.com/amorindev/go-tmpl/pkg/app/ecomm/products/domain"
+)
+
+type ProductRepo interface {
+	Insert(ctx context.Context, product *domain.Product) error
+	FindAll(ctx context.Context, limit int64, page int64) ([]*domain.Product, error)
+	Count(ctx context.Context) (int64, error)
+	Delete(ctx context.Context, id string) error
+}
+
+type ProductSrv interface {
+	GetAll(ctx context.Context, limit int64, page int64) ([]*domain.Product, int64, int64, error)
+	Create(ctx context.Context, product *domain.Product) error
+	Delete(ctx context.Context, id string) error
+}

--- a/pkg/app/ecomm/products/repository/mongo/count.go
+++ b/pkg/app/ecomm/products/repository/mongo/count.go
@@ -1,0 +1,16 @@
+package mongo
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+func (r *Repository) Count(ctx context.Context) (int64, error) {
+	count, err := r.Collection.CountDocuments(ctx, bson.M{})
+	if err != nil {
+		return 0, fmt.Errorf("failed to count products: %w", err)
+	}
+	return count, nil
+}

--- a/pkg/app/ecomm/products/repository/mongo/create_index.go
+++ b/pkg/app/ecomm/products/repository/mongo/create_index.go
@@ -1,0 +1,22 @@
+package mongo
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+)
+
+// * CreateIndexes sets a unique index on the "sku" field.
+func (r *Repository) CreateIndexes() error {
+	_, err := r.Collection.Indexes().CreateOne(context.Background(), mongo.IndexModel{
+		Keys:    bson.D{{Key: "product_items.sku", Value: 1}},
+		Options: options.Index().SetUnique(true).SetName("unique_sku"),
+	})
+	if err != nil {
+		return fmt.Errorf("error creating sku index: %w", err)
+	}
+	return nil
+}

--- a/pkg/app/ecomm/products/repository/mongo/delete.go
+++ b/pkg/app/ecomm/products/repository/mongo/delete.go
@@ -1,0 +1,27 @@
+package mongo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/amorindev/go-tmpl/pkg/shared/domain"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+func (r *Repository) Delete(ctx context.Context, id string) error {
+	oID, err := bson.ObjectIDFromHex(id)
+	if err != nil {
+		return domain.ErrIncorrectID
+	}
+
+	result, err := r.Collection.DeleteOne(ctx, bson.M{"_id": oID})
+	if err != nil {
+		return fmt.Errorf("error deleting product: %w", err)
+	}
+
+	if result.DeletedCount == 0 {
+		return domain.ErrNotFound
+	}
+
+	return nil
+}

--- a/pkg/app/ecomm/products/repository/mongo/find_all.go
+++ b/pkg/app/ecomm/products/repository/mongo/find_all.go
@@ -1,0 +1,119 @@
+package mongo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/amorindev/go-tmpl/pkg/app/ecomm/products/domain"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+)
+
+func (r *Repository) FindAll(ctx context.Context, limit int64, page int64) ([]*domain.Product, error) {
+	skip := (page - 1) * limit
+
+	pipeline := mongo.Pipeline{
+		// join with var_options
+		{{Key: "$lookup", Value: bson.D{
+			{Key: "from", Value: "var_options"},
+			{Key: "localField", Value: "product_items.var_option_ids"},
+			{Key: "foreignField", Value: "_id"},
+			{Key: "as", Value: "all_var_options"},
+		}}},
+		// join with variations
+		{{Key: "$lookup", Value: bson.D{
+			{Key: "from", Value: "variations"},
+			{Key: "localField", Value: "all_var_options.variation_id"},
+			{Key: "foreignField", Value: "_id"},
+			{Key: "as", Value: "all_variations"},
+		}}},
+		// join with categories
+		{{Key: "$lookup", Value: bson.D{
+			{Key: "from", Value: "categories"},
+			{Key: "localField", Value: "category_id"},
+			{Key: "foreignField", Value: "_id"},
+			{Key: "as", Value: "category"},
+		}}},
+		// extract the name field from category as category_name
+		{{Key: "$addFields", Value: bson.D{
+			{Key: "category_name", Value: bson.D{
+				{Key: "$cond", Value: bson.A{
+					bson.D{{Key: "$gt", Value: bson.A{bson.D{{Key: "$size", Value: "$category"}}, 0}}},
+					bson.D{{Key: "$arrayElemAt", Value: bson.A{"$category.name", 0}}},
+					"", // if there is no category
+				}},
+			}},
+		}}},
+
+		// rebuilding product_items with their options
+		{{Key: "$addFields", Value: bson.D{
+			{Key: "product_items", Value: bson.D{
+				{Key: "$map", Value: bson.D{
+					{Key: "input", Value: "$product_items"},
+					{Key: "as", Value: "item"},
+					{Key: "in", Value: bson.D{
+						{Key: "$mergeObjects", Value: bson.A{
+							"$$item",
+							bson.D{
+								{Key: "options", Value: bson.D{
+									{Key: "$map", Value: bson.D{
+										{Key: "input", Value: bson.D{
+											{Key: "$filter", Value: bson.D{
+												{Key: "input", Value: "$all_var_options"},
+												{Key: "as", Value: "opt"},
+												{Key: "cond", Value: bson.D{
+													{Key: "$in", Value: bson.A{"$$opt._id", "$$item.var_option_ids"}},
+												}},
+											}},
+										}},
+										{Key: "as", Value: "opt"},
+										{Key: "in", Value: bson.D{
+											{Key: "name", Value: bson.D{
+												{Key: "$first", Value: bson.D{
+													{Key: "$map", Value: bson.D{
+														{Key: "input", Value: bson.D{
+															{Key: "$filter", Value: bson.D{
+																{Key: "input", Value: "$all_variations"},
+																{Key: "as", Value: "v"},
+																{Key: "cond", Value: bson.D{
+																	{Key: "$eq", Value: bson.A{"$$v._id", "$$opt.variation_id"}},
+																}},
+															}},
+														}},
+														{Key: "as", Value: "v"},
+														{Key: "in", Value: "$$v.name"},
+													}},
+												}},
+											}},
+											{Key: "var_opt_name", Value: "$$opt.label"},
+											{Key: "var_opt_value", Value: "$$opt.value"},
+										}},
+									}},
+								}},
+							},
+						}},
+					}},
+				}},
+			}},
+		}}},
+
+		// pagination
+		{{Key: "$skip", Value: skip}},
+		{{Key: "$limit", Value: limit}},
+	}
+
+	var products []*domain.Product
+
+	cursor, err := r.Collection.Aggregate(ctx, pipeline)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute aggregate pipeline: %w", err)
+	}
+
+	defer cursor.Close(ctx)
+
+	if err := cursor.All(ctx, &products); err != nil {
+		return nil, fmt.Errorf("failed to decode products from cursor: %w", err)
+	}
+
+	return products, nil
+}

--- a/pkg/app/ecomm/products/repository/mongo/insert.go
+++ b/pkg/app/ecomm/products/repository/mongo/insert.go
@@ -1,0 +1,49 @@
+package mongo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/amorindev/go-tmpl/pkg/app/ecomm/products/domain"
+	dShared "github.com/amorindev/go-tmpl/pkg/shared/domain"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+)
+
+func (r *Repository) Insert(ctx context.Context, product *domain.Product) error {
+	id := bson.NewObjectID()
+	product.ID = id
+
+	for _, pItem := range product.ProductItems {
+		pItem.ID = bson.NewObjectID()
+		var oIDs []interface{}
+		for _, varOptID := range pItem.VarOptionIDs {
+			oID, err := bson.ObjectIDFromHex(varOptID.(string))
+			if err != nil {
+				return dShared.ErrIncorrectID
+			}
+			oIDs = append(oIDs, oID)
+		}
+		pItem.VarOptionIDs = oIDs
+	}
+
+	// Assign ID category
+	ctgOID, err := bson.ObjectIDFromHex(product.CategoryID.(string))
+	if err != nil {
+		return dShared.ErrIncorrectID
+	}
+	product.CategoryID = ctgOID
+
+	_, err = r.Collection.InsertOne(ctx, product)
+	if err != nil {
+		if mongo.IsDuplicateKeyError(err) {
+			return fmt.Errorf("%w: error inserting product: %w", dShared.ErrDuplicateKey, err)
+		}
+		return fmt.Errorf("error inserting product: %w", err)
+	}
+
+	product.ID = id.Hex()
+	product.CategoryID = ctgOID.Hex()
+
+	return nil
+}

--- a/pkg/app/ecomm/products/repository/mongo/repository.go
+++ b/pkg/app/ecomm/products/repository/mongo/repository.go
@@ -1,0 +1,20 @@
+package mongo
+
+import (
+	"github.com/amorindev/go-tmpl/pkg/app/ecomm/products/port"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+)
+
+var _ port.ProductRepo = &Repository{}
+
+type Repository struct {
+	Client     *mongo.Client
+	Collection *mongo.Collection
+}
+
+func NewProductRepo(client *mongo.Client, collection *mongo.Collection) *Repository {
+	return &Repository{
+		Client: client, 
+        Collection: collection,
+	}
+}

--- a/pkg/app/ecomm/products/service/create.go
+++ b/pkg/app/ecomm/products/service/create.go
@@ -1,0 +1,79 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/amorindev/go-tmpl/pkg/app/ecomm/products/domain"
+	"github.com/amorindev/go-tmpl/pkg/app/ecomm/products/helpers"
+	dShared "github.com/amorindev/go-tmpl/pkg/shared/domain"
+)
+
+func (s *Service) Create(ctx context.Context, product *domain.Product) error {
+	now := time.Now().UTC()
+	product.CreatedAt = &now
+	product.UpdatedAt = &now
+	product.Status = domain.ProductStatusActive
+
+	bucketFolderStruct := "products/"
+	product.FilePath = fmt.Sprintf("%s%s", bucketFolderStruct, product.FilePath)
+
+	uniqueFilePath, err := s.FileStorageSrv.UploadImage(ctx, product.FilePath, product.File, product.ContentType)
+	if err != nil {
+		return dShared.ManageError(err, "")
+	}
+	product.FilePath = uniqueFilePath
+
+	// to create the sku
+	ctg, err := s.CategoryRepo.Get(ctx, product.CategoryID.(string))
+	if err != nil {
+		return dShared.ManageError(err, "")
+	}
+	product.CategoryName = ctg.Name
+
+	for _, pItem := range product.ProductItems {
+		pItem.CreatedAt = &now
+		pItem.UpdatedAt = &now
+		pItem.FilePath = fmt.Sprintf("%s%s", bucketFolderStruct, pItem.FilePath)
+
+		// Create Sku
+		ids := make([]string, 0, len(pItem.VarOptionIDs))
+		for _, id := range pItem.VarOptionIDs {
+			ids = append(ids, id.(string))
+		}
+
+		varOptions, err := s.VarOptionRepo.FindByIDs(ctx, ids)
+		if err != nil {
+			return dShared.ManageError(err, "")
+		}
+
+		options := make([]*domain.Option, 0, len(pItem.VarOptionIDs))
+		for _, varOpt := range varOptions {
+			option := &domain.Option{
+				VarOptName: varOpt.Label,
+			}
+			options = append(options, option)
+		}
+
+		pItem.Options = options
+
+		pItem.Sku = helpers.GenerateItemSKU(product, pItem)
+		// we clean so as not to save in the database
+		pItem.Options = nil
+		product.CategoryName = ""
+
+		uniqueFP, err := s.FileStorageSrv.UploadImage(ctx, pItem.FilePath, pItem.File, pItem.ContentType)
+		if err != nil {
+			return dShared.ManageError(err, "")
+		}
+		pItem.FilePath = uniqueFP
+	}
+
+	err = s.ProductRepo.Insert(ctx, product)
+	if err != nil {
+		return dShared.ManageError(err, "")
+	}
+
+	return nil
+}

--- a/pkg/app/ecomm/products/service/delete.go
+++ b/pkg/app/ecomm/products/service/delete.go
@@ -1,0 +1,15 @@
+package service
+
+import (
+	"context"
+
+	"github.com/amorindev/go-tmpl/pkg/shared/domain"
+)
+
+func (s *Service) Delete(ctx context.Context, id string) error {
+	err := s.ProductRepo.Delete(ctx, id)
+	if err != nil {
+		return domain.ManageError(err, "")
+	}
+	return nil
+}

--- a/pkg/app/ecomm/products/service/get.all.go
+++ b/pkg/app/ecomm/products/service/get.all.go
@@ -1,0 +1,46 @@
+package service
+
+import (
+	"context"
+	"math"
+
+	"github.com/amorindev/go-tmpl/pkg/app/ecomm/products/domain"
+	"github.com/amorindev/go-tmpl/pkg/app/ecomm/products/helpers"
+	dShared "github.com/amorindev/go-tmpl/pkg/shared/domain"
+)
+
+func (s *Service) GetAll(ctx context.Context, limit int64, page int64) ([]*domain.Product, int64, int64, error) {
+	products, err := s.ProductRepo.FindAll(ctx, limit, page)
+	if err != nil {
+		return nil, 0, 0, dShared.ManageError(err, "")
+	}
+
+	for _, product := range products {
+		productUrl, err := s.FileStorageSrv.GetImage(ctx, product.FilePath)
+		if err != nil {
+			return nil, 0, 0, dShared.ManageError(err, "")
+		}
+		product.ImgUrl = productUrl
+
+		for _, pItem := range product.ProductItems {
+			pItemUrl, err := s.FileStorageSrv.GetImage(ctx, pItem.FilePath)
+			if err != nil {
+				return nil, 0, 0, dShared.ManageError(err, "")
+
+			}
+			pItem.ImgUrl = pItemUrl
+			pItem.FilePath = ""
+			pItem.VarOptionIDs = nil
+		}
+		product.FilePath = ""
+		helpers.CalculateVariations(product)
+	}
+
+	count, err := s.ProductRepo.Count(ctx)
+	if err != nil {
+		return nil, 0, 0, dShared.ManageError(err, "")
+	}
+	totalPages := int64(math.Ceil(float64(count) / float64(limit)))
+
+	return products, count, totalPages, nil
+}

--- a/pkg/app/ecomm/products/service/service.go
+++ b/pkg/app/ecomm/products/service/service.go
@@ -1,0 +1,31 @@
+package service
+
+import (
+	categoryP "github.com/amorindev/go-tmpl/pkg/app/ecomm/category/port"
+	productP "github.com/amorindev/go-tmpl/pkg/app/ecomm/products/port"
+	varOptP "github.com/amorindev/go-tmpl/pkg/app/ecomm/variations/port"
+	fileStgP "github.com/amorindev/go-tmpl/pkg/file-storage/port"
+)
+
+var _ productP.ProductSrv = &Service{}
+
+type Service struct {
+	ProductRepo    productP.ProductRepo
+	CategoryRepo   categoryP.CategoryRepo
+	FileStorageSrv fileStgP.FileStorageSrv
+	VarOptionRepo  varOptP.VarOptionRepo
+}
+
+func NewProductSrv(
+	productRepo productP.ProductRepo,
+	varOptionRepo varOptP.VarOptionRepo,
+	categoryRepo categoryP.CategoryRepo,
+	fileStorageSrv fileStgP.FileStorageSrv,
+) *Service {
+	return &Service{
+		ProductRepo:    productRepo,
+		VarOptionRepo:  varOptionRepo,
+		CategoryRepo:   categoryRepo,
+		FileStorageSrv: fileStorageSrv,
+	}
+}

--- a/pkg/app/ecomm/variations/port/ports_variation.go
+++ b/pkg/app/ecomm/variations/port/ports_variation.go
@@ -17,6 +17,7 @@ type VarOptionRepo interface {
 	Insert(ctx context.Context, varOption *domain.VarOption) error
 	Update(ctx context.Context, varOption *domain.VarOption) error
 	Delete(ctx context.Context, id string, variationID string) error
+	FindByIDs(ctx context.Context,ids []string) ([]*domain.VarOption,error)
 }
 
 type VariationSrv interface {

--- a/pkg/app/ecomm/variations/repository/var-option/mongo/find_by_ids.go
+++ b/pkg/app/ecomm/variations/repository/var-option/mongo/find_by_ids.go
@@ -1,0 +1,37 @@
+package mongo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/amorindev/go-tmpl/pkg/app/ecomm/variations/domain"
+	dShared "github.com/amorindev/go-tmpl/pkg/shared/domain"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+func (r *Repository) FindByIDs(ctx context.Context, ids []string) ([]*domain.VarOption, error) {
+
+	objectIDs := make([]bson.ObjectID, 0, len(ids))
+	for _, idStr := range ids {
+		oid, err := bson.ObjectIDFromHex(idStr)
+		if err != nil {
+			return nil, fmt.Errorf("%w: invalid id %s: %w", dShared.ErrIncorrectID, idStr, err)
+		}
+		objectIDs = append(objectIDs, oid)
+	}
+
+	filter := bson.M{"_id": bson.M{"$in": objectIDs}}
+
+	cursor, err := r.Collection.Find(ctx, filter)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find VarOptions by IDs: %w", err)
+	}
+	defer cursor.Close(ctx)
+
+	var results []*domain.VarOption
+	if err := cursor.All(ctx, &results); err != nil {
+		return nil, fmt.Errorf("failed to decode VarOptions: %w", err)
+	}
+
+	return results, nil
+}


### PR DESCRIPTION
### Description
This PR adds initial Product management functionality to the backend, including create, list, and delete operations.

### Key changes:

Handlers (REST API)
- POST /products → create a product (supports products with and without variants).
- GET /products → list products with pagination.
- DELETE /products/:id → delete a product by ID.

Domain
- Defined Product, ProductItem, Option, and Variation entities.
- Added helpers for SKU generation and variation calculation.

Repository (MongoDB)
- Implemented Insert, FindAll with aggregation, Count, and Delete.
- Added unique index for SKU.

Service Layer
- Create product with category assignment.
- Generate SKU and handle timestamps.
- Support for single-item products and variant-based products.

Admin Panel (UI)
- Implemented product creation form (with and without variants).
- Integrated product listing view.
- Added product delete flow.
- Added error handling and feedback messages on the UI.

<img width="886" height="251" alt="image" src="https://github.com/user-attachments/assets/6da86ce9-f1ed-42e6-ac14-6ca8e2d89107" />

<img width="886" height="178" alt="image" src="https://github.com/user-attachments/assets/2cbc1eb8-a6cc-4fd6-b2ab-fa6ac945d635" />

<img width="886" height="138" alt="image" src="https://github.com/user-attachments/assets/b420ecdc-fb86-47a4-b44d-d87ea3d20c32" />

Close #5 


