### PR TITLE
refactor(product.html): use API_BASE for products, categories and variations endpoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 include .env
 
 run:
-	@go run main.go
+	@go run cmd/api/main.go
 
 compose-dev:
 	@docker-compose -f docker-compose.dev.yml --env-file .env up

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -2,16 +2,18 @@ package main
 
 import (
 	"cmp"
+	"log"
 	"os"
 
 	"github.com/amorindev/go-tmpl/cmd/api/server"
+	"github.com/joho/godotenv"
 )
 
 func main() {
-	/* err := godotenv.Load()
+	err := godotenv.Load()
 	if err != nil {
 		log.Fatalf("Failed to load .env file: %v", err)
-	} */
+	}
 
 	hsp := cmp.Or(os.Getenv("HTTP_SERVER_PORT"), "8000")
 

--- a/pkg/app/admin/api/web/templates/products.html
+++ b/pkg/app/admin/api/web/templates/products.html
@@ -269,9 +269,9 @@
 <script>
   let variationsData = [];
 
-  const API_PRODUCTS = "http://localhost:8000/v1/products";
-  const API_CATEGORIES = "http://localhost:8000/v1/categories";
-  const API_VARIATIONS = "http://localhost:8000/v1/variations/options";
+  const API_PRODUCTS = `${API_BASE}/v1/products`;
+  const API_CATEGORIES = `${API_BASE}/v1/categories`;
+  const API_VARIATIONS = `${API_BASE}/v1/variations/options`;
 
   // Modal controls
   function openProductModal(id = "", name = "", desc = "", category_id = "") {


### PR DESCRIPTION
### Description
This PR updates product.html to use the API_BASE constant for building API endpoints.  
Replaced hardcoded URLs with API_BASE for:
- Products
- Categories
- Variations options