### PR TITLE
Split main entrypoint into dev and prod environments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 include .env
 
 run:
-	@go run cmd/api/main.go
+	@go run cmd/api/env/dev/main.go
 
 compose-dev:
 	@docker-compose -f docker-compose.dev.yml --env-file .env up

--- a/cmd/api/env/dev/main.go
+++ b/cmd/api/env/dev/main.go
@@ -2,16 +2,18 @@ package main
 
 import (
 	"cmp"
+	"log"
 	"os"
 
 	"github.com/amorindev/go-tmpl/cmd/api/server"
+	"github.com/joho/godotenv"
 )
 
 func main() {
-	/* err := godotenv.Load()
+	err := godotenv.Load()
 	if err != nil {
 		log.Fatalf("Failed to load .env file: %v", err)
-	} */
+	}
 
 	hsp := cmp.Or(os.Getenv("HTTP_SERVER_PORT"), "8000")
 

--- a/cmd/api/env/prod/main.go
+++ b/cmd/api/env/prod/main.go
@@ -1,0 +1,16 @@
+package main
+
+
+import (
+	"cmp"
+	"os"
+
+	"github.com/amorindev/go-tmpl/cmd/api/server"
+)
+
+func main() {
+	hsp := cmp.Or(os.Getenv("HTTP_SERVER_PORT"), "8000")
+
+	httpSrv := server.NewHttpServer(hsp)
+	httpSrv.Start()
+}

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,5 +1,5 @@
 [phases.build]
-cmds = ['''GOOS=linux GOARCH=amd64 go build -ldflags='-s' -o=./bin/linux_amd64/api ./cmd/api/main.go''']
+cmds = ['''GOOS=linux GOARCH=amd64 go build -ldflags='-s' -o=./bin/linux_amd64/api ./cmd/api/env/prod/main.go''']
 
 [start]
 cmd = './bin/linux_amd64/api'


### PR DESCRIPTION
- Moved cmd/api/main.go to cmd/api/env/dev/main.go
- Added .env loading in dev environment
- Created new cmd/api/env/prod/main.go without dotenv
- Updated Makefile to run dev main
- Updated nixpacks.toml to build using prod main